### PR TITLE
fix(auth): マジックリンクトークン検証が常に失敗するバグを修正

### DIFF
--- a/src/lib/auth/token.ts
+++ b/src/lib/auth/token.ts
@@ -46,35 +46,25 @@ export async function createMagicLinkToken(email: string): Promise<string> {
  * トークンを検証して対応するメールアドレスを返す。
  * 無効（存在しない / 期限切れ / 使用済み）の場合は null を返す。
  *
- * 【設計】
- * prisma.update の where は @unique フィールドのみ確実にフィルタされる。
- * 非ユニーク列（usedAt / expiresAt）の追加条件は adapter-pg では動作が
- * 不安定なため、updateMany（任意 where を完全サポート）を使う。
- * - updateMany で "未使用かつ期限内" を条件に atomic にマーク
- * - count === 0 なら無効（存在しない / 使用済み / 期限切れ）
- * - count > 0 なら有効 → 別途 email を取得して返す
+ * 【設計メモ】
+ * @prisma/adapter-pg は updateMany / update の複合 WHERE 条件（非ユニーク列）を
+ * 正しく処理できないケースがある。
+ * そのため「findUnique で取得 → アプリ側で検証 → id(@unique) で update」に統一する。
+ * MVP スコープでは同一リンクへの並行クリックは発生しないため、この方式で十分。
  */
 export async function consumeMagicLinkToken(
   token: string,
 ): Promise<string | null> {
-  const now = new Date();
-
-  // Step 1: email を先に取得（存在確認）
   const record = await prisma.magicLinkToken.findUnique({ where: { token } });
   if (!record) return null;
+  if (record.usedAt !== null) return null;      // 使用済み
+  if (record.expiresAt < new Date()) return null; // 期限切れ
 
-  // Step 2: "未使用かつ期限内" の場合のみ atomic に usedAt をセット
-  const { count } = await prisma.magicLinkToken.updateMany({
-    where: {
-      token,
-      usedAt: null,               // 未使用であること
-      expiresAt: { gte: now },    // 期限内であること
-    },
-    data: { usedAt: now },
+  // id (@unique) のみで update → adapter-pg でも確実に動作する
+  await prisma.magicLinkToken.update({
+    where: { id: record.id },
+    data: { usedAt: new Date() },
   });
-
-  // count === 0 は「使用済み or 期限切れ」
-  if (count === 0) return null;
 
   return record.email;
 }


### PR DESCRIPTION
## 概要

マジックリンクURL をクリックすると常に `/login?error=expired` にリダイレクトされるバグを修正する。

## 原因

`@prisma/adapter-pg` では以下の2パターンがいずれも正常動作しなかった。

| 試行 | 実装 | 問題 |
|---|---|---|
| 1回目 | `update(where: { token, usedAt: null, expiresAt: {gte} })` | `@unique` 以外のフィールドが where に効かず例外になる |
| 2回目 | `updateMany(where: { token, usedAt: null, expiresAt: {gte} })` | 複合 WHERE が処理されず常に `count === 0` |

## 変更内容

`findUnique` でレコードを取得しアプリ側でチェック、`update` は `id`（`@unique`）のみで実行する方式に統一した。
