### PR TITLE
fix(auth): dev環境のログURL改善・トークン末尾の不正文字サニタイズ

### DIFF
--- a/src/app/api/auth/magic-link/route.ts
+++ b/src/app/api/auth/magic-link/route.ts
@@ -31,6 +31,11 @@ export async function POST(req: NextRequest) {
     const magicLink = `${appUrl}/api/auth/verify?token=${token}`;
     const expiryMin = process.env.MAGIC_LINK_EXPIRY_MINUTES ?? "30";
 
+    // dev 環境ではコピーしやすいよう URL を単独行で出力
+    if (process.env.NODE_ENV !== "production") {
+      console.log("\n[magic-link] ✉ LOGIN URL:\n" + magicLink + "\n");
+    }
+
     const result = await sendEmail({
       to: email,
       subject: "【就活締切トラッカー】ログインリンク",

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -13,7 +13,9 @@ import { createSessionToken, sessionCookieOptions } from "@/lib/auth/session";
 import { prisma } from "@/lib/prisma";
 
 export async function GET(req: NextRequest) {
-  const token = req.nextUrl.searchParams.get("token") ?? "";
+  // コピー時の末尾 \ 等の非hex文字を除去するサニタイズ
+  const rawToken = req.nextUrl.searchParams.get("token") ?? "";
+  const token = rawToken.replace(/[^0-9a-f]/gi, "");
 
   if (!token) {
     return NextResponse.redirect(new URL("/login?error=invalid", req.url));
@@ -21,7 +23,9 @@ export async function GET(req: NextRequest) {
 
   let email: string | null = null;
   try {
+    console.log("[verify] token received:", token.slice(0, 8) + "...");
     email = await consumeMagicLinkToken(token);
+    console.log("[verify] consumeMagicLinkToken result:", email);
   } catch (err) {
     console.error("[verify] consumeMagicLinkToken error:", err);
     return NextResponse.redirect(new URL("/login?error=server", req.url));
@@ -29,6 +33,7 @@ export async function GET(req: NextRequest) {
 
   if (!email) {
     // トークン無効（存在しない / 期限切れ / 使用済み）
+    console.log("[verify] email is null → redirect expired");
     return NextResponse.redirect(new URL("/login?error=expired", req.url));
   }
 

--- a/src/lib/auth/token.ts
+++ b/src/lib/auth/token.ts
@@ -56,15 +56,20 @@ export async function consumeMagicLinkToken(
   token: string,
 ): Promise<string | null> {
   const record = await prisma.magicLinkToken.findUnique({ where: { token } });
+  console.log("[token] findUnique result:", record
+    ? { id: record.id, usedAt: record.usedAt, expiresAt: record.expiresAt, now: new Date() }
+    : "NOT FOUND"
+  );
   if (!record) return null;
-  if (record.usedAt !== null) return null;      // 使用済み
-  if (record.expiresAt < new Date()) return null; // 期限切れ
+  if (record.usedAt !== null) { console.log("[token] already used"); return null; }
+  if (record.expiresAt < new Date()) { console.log("[token] expired"); return null; }
 
   // id (@unique) のみで update → adapter-pg でも確実に動作する
   await prisma.magicLinkToken.update({
     where: { id: record.id },
     data: { usedAt: new Date() },
   });
+  console.log("[token] update ok, returning email:", record.email);
 
   return record.email;
 }


### PR DESCRIPTION

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/app/api/auth/magic-link/route.ts` | dev 環境でログイン URL を **単独行** で出力（コピーしやすい形式） |
| `src/app/api/auth/verify/route.ts` | 受け取ったトークンから非 hex 文字（`\` 等）を除去するサニタイズを追加 |
| `src/lib/auth/token.ts` | デバッグログを追加（原因調査用。本変更に含む） |

## 確認手順

1. `npm run dev` 起動
2. `/login` でメール送信
3. ターミナルに以下の形式で URL が出力されることを確認
