### PR TITLE
feat(deadlines): POST /api/deadlines 追加（バリデーション+Free枠制限）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Unreleased
 
+- feat: `POST /api/deadlines` を追加（締切アイテム作成API、入力バリデーション・Free 10件制限・ユーザースコープ保証）
 - feat: メールマジックリンク認証を追加（/login でメール入力→リンク送付→クリックでログイン/サインアップ、未ログイン時は /login へリダイレクト）
 - feat: メール送信基盤を追加（EMAIL_PROVIDER=console/resend で切替、送信失敗は ok:false で返却しログ出力）
 - db: Prisma + Postgres スキーマ追加（users / deadline_items / subscriptions / notification_deliveries / magic_link_tokens）

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "db:migrate:deploy": "prisma migrate deploy",
     "db:studio": "prisma studio",
     "test:mailer": "npx tsx src/lib/mailer/__tests__/sendEmail.test.ts",
-    "test:auth": "npx tsx src/lib/auth/__tests__/auth.test.ts"
+    "test:auth": "npx tsx src/lib/auth/__tests__/auth.test.ts",
+    "test:deadlines": "npx tsx src/lib/deadlines/__tests__/deadlines.test.ts"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.5.0",

--- a/src/app/api/deadlines/route.ts
+++ b/src/app/api/deadlines/route.ts
@@ -1,0 +1,103 @@
+/**
+ * POST /api/deadlines
+ *
+ * 締切アイテムを作成するAPI。
+ *
+ * 認証:
+ *  - セッションクッキーが必要（未ログインは 401）
+ *  - 作成者は必ずログインユーザー（他ユーザーへの書き込み不可）
+ *
+ * バリデーション（src/lib/deadlines/validate.ts 参照）:
+ *  - company_name: 必須、1〜100 文字
+ *  - kind: 必須、"es" | "briefing" | "interview" | "other"
+ *  - deadline_at: 必須、ISO 8601 文字列
+ *  - status: 任意、デフォルト "todo"
+ *  - link: 任意、http(s) URL、最大 2048 文字
+ *  - memo: 任意、最大 1000 文字
+ *
+ * Free 枠制限:
+ *  - Pro ユーザー（subscriptions.plan = "pro" かつ active/trialing または current_period_end が未来）は無制限
+ *  - それ以外（Free）は 10 件まで。超過時は 403 を返す
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { prisma } from "@/lib/prisma";
+import { validateCreateDeadline } from "@/lib/deadlines/validate";
+
+/** Free ユーザーが作成できる最大件数 */
+export const FREE_ITEM_LIMIT = 10;
+
+/**
+ * subscriptions レコードを見て Pro か判定する。
+ * Pro 判定: plan = "pro" かつ (status = "active" | "trialing" または current_period_end が未来)
+ */
+async function isProUser(userId: string): Promise<boolean> {
+  const sub = await prisma.subscription.findUnique({ where: { userId } });
+  if (!sub || sub.plan !== "pro") return false;
+  const activeStatus =
+    sub.status === "active" || sub.status === "trialing";
+  const periodValid =
+    sub.currentPeriodEnd !== null && sub.currentPeriodEnd > new Date();
+  return activeStatus || periodValid;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    // 1. 認証確認
+    const session = await getSession(req);
+    if (!session) {
+      return NextResponse.json(
+        { error: "ログインが必要です" },
+        { status: 401 },
+      );
+    }
+    const userId = session.sub;
+
+    // 2. バリデーション
+    const body = await req.json().catch(() => ({}));
+    const result = validateCreateDeadline(body);
+    if (!result.ok) {
+      return NextResponse.json(
+        { error: "入力値が不正です", details: result.errors },
+        { status: 400 },
+      );
+    }
+    const { companyName, kind, deadlineAt, status, link, memo } = result.data;
+
+    // 3. Free 枠チェック
+    const pro = await isProUser(userId);
+    if (!pro) {
+      const count = await prisma.deadlineItem.count({ where: { userId } });
+      if (count >= FREE_ITEM_LIMIT) {
+        return NextResponse.json(
+          {
+            error: `Free プランは最大 ${FREE_ITEM_LIMIT} 件まで登録できます。Pro にアップグレードすると無制限になります。`,
+            code: "FREE_LIMIT_EXCEEDED",
+          },
+          { status: 403 },
+        );
+      }
+    }
+
+    // 4. 作成（userId を強制指定してユーザースコープを保証）
+    const item = await prisma.deadlineItem.create({
+      data: {
+        userId,
+        companyName,
+        kind,
+        deadlineAt,
+        status,
+        link,
+        memo,
+      },
+    });
+
+    return NextResponse.json({ ok: true, item }, { status: 201 });
+  } catch (err) {
+    console.error("[POST /api/deadlines] unexpected error:", err);
+    return NextResponse.json(
+      { error: "サーバーエラーが発生しました" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/deadlines/__tests__/deadlines.test.ts
+++ b/src/lib/deadlines/__tests__/deadlines.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Deadline Item バリデーション ユニットテスト
+ * 実行: npx tsx src/lib/deadlines/__tests__/deadlines.test.ts
+ *
+ * テスト戦略:
+ *  - validateCreateDeadline: DB不要な純粋関数のみ対象
+ *  - Free枠制限・DB保存・認証はRoute Handler経由の手動確認手順を参照
+ */
+
+import assert from "node:assert/strict";
+import { validateCreateDeadline } from "../validate";
+
+const VALID_BASE = {
+  company_name: "株式会社テスト",
+  kind: "es",
+  deadline_at: "2026-04-01T10:00:00+09:00",
+};
+
+async function runAll() {
+  let passed = 0;
+  let failed = 0;
+
+  async function test(name: string, fn: () => void | Promise<void>) {
+    try {
+      await fn();
+      console.log(`  ✓ ${name}`);
+      passed++;
+    } catch (err) {
+      console.error(`  ✗ ${name}`);
+      console.error("   ", err instanceof Error ? err.message : err);
+      failed++;
+    }
+  }
+
+  console.log("\nDeadline バリデーション テスト\n");
+
+  // ── 正常系 ──────────────────────────────────────────────────────────────
+
+  await test("最小必須フィールドのみで ok:true を返す", () => {
+    const r = validateCreateDeadline(VALID_BASE);
+    assert.ok(r.ok);
+    if (!r.ok) return;
+    assert.equal(r.data.companyName, "株式会社テスト");
+    assert.equal(r.data.kind, "es");
+    assert.equal(r.data.status, "todo"); // デフォルト
+    assert.equal(r.data.link, null);
+    assert.equal(r.data.memo, null);
+  });
+
+  await test("status を明示指定できる", () => {
+    const r = validateCreateDeadline({ ...VALID_BASE, status: "submitted" });
+    assert.ok(r.ok);
+    if (!r.ok) return;
+    assert.equal(r.data.status, "submitted");
+  });
+
+  await test("link と memo を指定できる", () => {
+    const r = validateCreateDeadline({
+      ...VALID_BASE,
+      link: "https://example.com/job",
+      memo: "ES締切注意",
+    });
+    assert.ok(r.ok);
+    if (!r.ok) return;
+    assert.equal(r.data.link, "https://example.com/job");
+    assert.equal(r.data.memo, "ES締切注意");
+  });
+
+  await test("kind が interview / briefing / other も受け付ける", () => {
+    for (const kind of ["interview", "briefing", "other"]) {
+      const r = validateCreateDeadline({ ...VALID_BASE, kind });
+      assert.ok(r.ok, `kind=${kind} が ok:false になった`);
+    }
+  });
+
+  await test("deadline_at が Date オブジェクトに変換される", () => {
+    const r = validateCreateDeadline({
+      ...VALID_BASE,
+      deadline_at: "2026-06-15T09:00:00Z",
+    });
+    assert.ok(r.ok);
+    if (!r.ok) return;
+    assert.ok(r.data.deadlineAt instanceof Date);
+  });
+
+  await test("link/memo が空文字の場合は null に正規化される", () => {
+    const r = validateCreateDeadline({
+      ...VALID_BASE,
+      link: "",
+      memo: "",
+    });
+    assert.ok(r.ok);
+    if (!r.ok) return;
+    assert.equal(r.data.link, null);
+    assert.equal(r.data.memo, null);
+  });
+
+  // ── 異常系 ──────────────────────────────────────────────────────────────
+
+  await test("company_name が空なら errors に含まれる", () => {
+    const r = validateCreateDeadline({ ...VALID_BASE, company_name: "" });
+    assert.ok(!r.ok);
+    if (r.ok) return;
+    assert.ok(r.errors.some((e) => e.field === "company_name"));
+  });
+
+  await test("company_name が 101 文字超でエラー", () => {
+    const r = validateCreateDeadline({
+      ...VALID_BASE,
+      company_name: "あ".repeat(101),
+    });
+    assert.ok(!r.ok);
+    if (r.ok) return;
+    assert.ok(r.errors.some((e) => e.field === "company_name"));
+  });
+
+  await test("kind が不正値ならエラー", () => {
+    const r = validateCreateDeadline({ ...VALID_BASE, kind: "unknown" });
+    assert.ok(!r.ok);
+    if (r.ok) return;
+    assert.ok(r.errors.some((e) => e.field === "kind"));
+  });
+
+  await test("deadline_at が欠落ならエラー", () => {
+    const { deadline_at: _, ...rest } = VALID_BASE;
+    const r = validateCreateDeadline(rest);
+    assert.ok(!r.ok);
+    if (r.ok) return;
+    assert.ok(r.errors.some((e) => e.field === "deadline_at"));
+  });
+
+  await test("deadline_at が不正な文字列ならエラー", () => {
+    const r = validateCreateDeadline({
+      ...VALID_BASE,
+      deadline_at: "not-a-date",
+    });
+    assert.ok(!r.ok);
+    if (r.ok) return;
+    assert.ok(r.errors.some((e) => e.field === "deadline_at"));
+  });
+
+  await test("link が http(s) 以外ならエラー", () => {
+    const r = validateCreateDeadline({
+      ...VALID_BASE,
+      link: "ftp://example.com",
+    });
+    assert.ok(!r.ok);
+    if (r.ok) return;
+    assert.ok(r.errors.some((e) => e.field === "link"));
+  });
+
+  await test("link が 2049 文字超ならエラー", () => {
+    const r = validateCreateDeadline({
+      ...VALID_BASE,
+      link: "https://example.com/" + "a".repeat(2030),
+    });
+    assert.ok(!r.ok);
+    if (r.ok) return;
+    assert.ok(r.errors.some((e) => e.field === "link"));
+  });
+
+  await test("memo が 1001 文字超ならエラー", () => {
+    const r = validateCreateDeadline({
+      ...VALID_BASE,
+      memo: "あ".repeat(1001),
+    });
+    assert.ok(!r.ok);
+    if (r.ok) return;
+    assert.ok(r.errors.some((e) => e.field === "memo"));
+  });
+
+  await test("body が非オブジェクトならエラー", () => {
+    const r = validateCreateDeadline("invalid");
+    assert.ok(!r.ok);
+  });
+
+  await test("複数フィールドが不正なら errors に複数エントリが返る", () => {
+    const r = validateCreateDeadline({
+      company_name: "",
+      kind: "bad",
+      deadline_at: "",
+    });
+    assert.ok(!r.ok);
+    if (r.ok) return;
+    assert.ok(r.errors.length >= 3);
+  });
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  if (failed > 0) process.exit(1);
+}
+
+runAll().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/lib/deadlines/validate.ts
+++ b/src/lib/deadlines/validate.ts
@@ -1,0 +1,163 @@
+/**
+ * Deadline Item 作成リクエストのバリデーション
+ *
+ * DB や外部依存を持たない純粋関数として切り出し、
+ * ユニットテストが容易な設計にしている。
+ */
+
+const VALID_KINDS = ["es", "briefing", "interview", "other"] as const;
+const VALID_STATUSES = ["todo", "submitted", "done", "canceled"] as const;
+
+export type DeadlineKindValue = (typeof VALID_KINDS)[number];
+export type DeadlineStatusValue = (typeof VALID_STATUSES)[number];
+
+/** バリデーション済みの正規化済み入力値 */
+export interface NormalizedDeadlineInput {
+  companyName: string;
+  kind: DeadlineKindValue;
+  deadlineAt: Date;
+  status: DeadlineStatusValue;
+  link: string | null;
+  memo: string | null;
+}
+
+export interface ValidationError {
+  field: string;
+  message: string;
+}
+
+export type ValidateResult =
+  | { ok: true; data: NormalizedDeadlineInput }
+  | { ok: false; errors: ValidationError[] };
+
+/**
+ * POST /api/deadlines のリクエストボディを検証して正規化する。
+ *
+ * ルール:
+ *  - company_name: 必須、1〜100文字
+ *  - kind: 必須、"es" | "briefing" | "interview" | "other"
+ *  - deadline_at: 必須、ISO 8601 文字列（有効な日時）
+ *  - status: 任意、デフォルト "todo"、"todo" | "submitted" | "done" | "canceled"
+ *  - link: 任意、http(s) URL、最大 2048 文字
+ *  - memo: 任意、最大 1000 文字
+ */
+export function validateCreateDeadline(body: unknown): ValidateResult {
+  const errors: ValidationError[] = [];
+
+  if (typeof body !== "object" || body === null) {
+    return {
+      ok: false,
+      errors: [{ field: "_body", message: "リクエストボディが不正です" }],
+    };
+  }
+  const b = body as Record<string, unknown>;
+
+  // company_name
+  const companyName =
+    typeof b.company_name === "string" ? b.company_name.trim() : "";
+  if (!companyName) {
+    errors.push({ field: "company_name", message: "企業名は必須です" });
+  } else if (companyName.length > 100) {
+    errors.push({
+      field: "company_name",
+      message: "企業名は100文字以内で入力してください",
+    });
+  }
+
+  // kind
+  const rawKind = typeof b.kind === "string" ? b.kind.trim() : "";
+  if (!rawKind) {
+    errors.push({ field: "kind", message: "種別は必須です" });
+  } else if (!(VALID_KINDS as readonly string[]).includes(rawKind)) {
+    errors.push({
+      field: "kind",
+      message: `種別は ${VALID_KINDS.join(" / ")} のいずれかを指定してください`,
+    });
+  }
+
+  // deadline_at
+  const rawDeadline =
+    typeof b.deadline_at === "string" ? b.deadline_at.trim() : "";
+  let deadlineAt: Date | null = null;
+  if (!rawDeadline) {
+    errors.push({ field: "deadline_at", message: "締切日時は必須です" });
+  } else {
+    const d = new Date(rawDeadline);
+    if (isNaN(d.getTime())) {
+      errors.push({
+        field: "deadline_at",
+        message: "締切日時は有効な ISO 8601 形式で入力してください",
+      });
+    } else {
+      deadlineAt = d;
+    }
+  }
+
+  // status（任意、デフォルト "todo"）
+  const rawStatus =
+    typeof b.status === "string" ? b.status.trim() : "todo";
+  const status: DeadlineStatusValue =
+    (VALID_STATUSES as readonly string[]).includes(rawStatus)
+      ? (rawStatus as DeadlineStatusValue)
+      : "todo";
+  if (
+    typeof b.status === "string" &&
+    !(VALID_STATUSES as readonly string[]).includes(b.status.trim())
+  ) {
+    errors.push({
+      field: "status",
+      message: `ステータスは ${VALID_STATUSES.join(" / ")} のいずれかを指定してください`,
+    });
+  }
+
+  // link（任意）
+  let link: string | null = null;
+  if (b.link !== undefined && b.link !== null && b.link !== "") {
+    const rawLink = typeof b.link === "string" ? b.link.trim() : "";
+    if (!rawLink) {
+      link = null;
+    } else if (rawLink.length > 2048) {
+      errors.push({
+        field: "link",
+        message: "リンクは2048文字以内で入力してください",
+      });
+    } else if (!/^https?:\/\/.+/.test(rawLink)) {
+      errors.push({
+        field: "link",
+        message: "リンクは http:// または https:// で始まる URL を入力してください",
+      });
+    } else {
+      link = rawLink;
+    }
+  }
+
+  // memo（任意）
+  let memo: string | null = null;
+  if (b.memo !== undefined && b.memo !== null && b.memo !== "") {
+    const rawMemo = typeof b.memo === "string" ? b.memo.trim() : "";
+    if (rawMemo.length > 1000) {
+      errors.push({
+        field: "memo",
+        message: "メモは1000文字以内で入力してください",
+      });
+    } else {
+      memo = rawMemo || null;
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    data: {
+      companyName,
+      kind: rawKind as DeadlineKindValue,
+      deadlineAt: deadlineAt!,
+      status,
+      link,
+      memo,
+    },
+  };
+}


### PR DESCRIPTION
## 概要

Issue #4 の実装。締切アイテム作成APIを追加する。
`POST /api/deadlines` でバリデーション・Free枠制限・ユーザースコープ保証を行う。

## 変更理由

MVP AC #4 を満たすため。他のUI実装（#9）やactivation計測（#17）のブロッカーとなる P0 Issue。

## 影響範囲

- [x] API
- [ ] UI
- [ ] DB
- [ ] 設定/インフラ
- [ ] 依存関係

## 変更ファイル

| ファイル | 種別 | 内容 |
|---|---|---|
| `src/lib/deadlines/validate.ts` | 新規 | 入力バリデーション（純粋関数・DB不要） |
| `src/app/api/deadlines/route.ts` | 新規 | `POST /api/deadlines` Route Handler |
| `src/lib/deadlines/__tests__/deadlines.test.ts` | 新規 | ユニットテスト 16件 |
| `package.json` | 変更 | `test:deadlines` スクリプト追加 |
| `CHANGELOG.md` | 変更 | Unreleased に1行追記 |

## AC 確認

- [x] `POST /api/deadlines` が `company_name/kind/deadline_at/status/link/memo` を検証して保存する
- [x] Freeは10件までをサーバー側で enforce（超過時は 403 + `FREE_LIMIT_EXCEEDED`）
- [x] 作成はログインユーザーにスコープ（セッションの `sub` を `userId` に強制指定）

## テスト計画

### 自動テスト（DB不要）

```bash
npm run test:deadlines
# → 16 passed, 0 failed