### PR TITLE
fix(#9): deadline_at に +09:00 を付与して JST を明示（タイムゾーンずれを修正）

### DIFF
--- a/src/app/deadline/new/DeadlineForm.tsx
+++ b/src/app/deadline/new/DeadlineForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { KIND_LABEL } from "@/lib/deadlines/format";
 
 type FieldErrors = Record<string, string>;
@@ -55,7 +56,9 @@ export default function DeadlineForm() {
         body: JSON.stringify({
           company_name: companyName.trim(),
           kind,
-          deadline_at: deadlineAt, // "YYYY-MM-DDTHH:MM" をそのまま渡す（Date として有効）
+          // datetime-local は TZ なしで返るため +09:00 を付与して JST を明示する
+          // （サーバーが UTC 環境でも正しい時刻で保存される）
+          deadline_at: deadlineAt ? deadlineAt + "+09:00" : "",
           link: link.trim() || undefined,
           memo: memo.trim() || undefined,
         }),
@@ -269,12 +272,12 @@ export default function DeadlineForm() {
         >
           {isSubmitting ? "保存中..." : "作成する"}
         </button>
-        <a
+        <Link
           href="/dashboard"
           className="text-sm text-slate-500 underline hover:text-slate-700"
         >
           キャンセル
-        </a>
+        </Link>
       </div>
     </form>
   );


### PR DESCRIPTION
## 概要

`/deadline/new` フォームで締切日時を登録すると、UTC 環境のサーバーで
9時間ずれて保存されるバグを修正する。

## 変更理由

`<input type="datetime-local">` はブラウザが `"2026-04-01T10:00"` のように
**タイムゾーンなし**の文字列を返す。
これをそのまま API へ渡すと、Vercel など UTC 環境のサーバーは
`2026-04-01T10:00 UTC = JST 19:00` として解釈するため、
ユーザーが入力した時刻より9時間後に保存されてしまう。

`deadline_at` に `+09:00` を付与し ISO 8601 の JST として明示することで修正する。

## 影響範囲

- [x] UI
- [ ] API
- [ ] DB
- [ ] 設定/インフラ
- [ ] 依存関係

## 確認手順

1. ログイン済みで `/deadline/new` へアクセス
2. 締切日時に `2026/04/01 10:00` を入力して作成する
3. ダッシュボードに遷移後、作成したアイテムの表示時刻が **10:00** になっていること
   （修正前は 19:00 になっていた）

## スクリーンショット/ログ

（手動確認にて代替）