### PR TITLE
feat: #11 Stripe Webhook（署名検証 → subscriptions 冪等 upsert）

### DIFF
--- a/src/lib/stripe/webhook.ts
+++ b/src/lib/stripe/webhook.ts
@@ -52,9 +52,11 @@ export async function upsertSubscription(
       ? subscription.customer
       : subscription.customer.id;
 
+  // Stripe SDK v20 では current_period_end は SubscriptionItem に移動
+  const firstItem = subscription.items.data[0];
   const currentPeriodEnd =
-    subscription.current_period_end != null
-      ? new Date(subscription.current_period_end * 1000)
+    firstItem?.current_period_end != null
+      ? new Date(firstItem.current_period_end * 1000)
       : null;
 
   const plan = resolveSubscriptionPlan(subscription.status, currentPeriodEnd);


### PR DESCRIPTION
## 概要

Stripe から送信される Webhook を受け取り、課金状態を DB に同期する。
`POST /api/stripe/webhook` に署名検証・subscriptions upsert・Pro 判定を実装。

## 変更理由

Issue #11（MVP P0）。Stripe Checkout で課金完了後、DB の subscriptions が更新されないとアプリ内の Pro/Free 判定が機能しないため。

## 影響範囲

- [x] API
- [ ] UI
- [ ] DB
- [x] 設定/インフラ
- [ ] 依存関係

## 変更ファイル一覧

| ファイル | 変更種別 | 概要 |
|---|---|---|
| `src/app/api/stripe/webhook/route.ts` | 新規 | Webhook ルートハンドラ（署名検証・イベントルーティング） |
| `src/lib/stripe/webhook.ts` | 新規 | `upsertSubscription` / `resolveSubscriptionPlan` ユーティリティ |
| `src/lib/stripe/__tests__/webhook.test.ts` | 新規 | `resolveSubscriptionPlan` 単体テスト（7ケース） |
| `.env.example` | 更新 | `STRIPE_WEBHOOK_SECRET` を追加 |
| `package.json` | 更新 | `test:webhook` スクリプトを追加 |
| `CHANGELOG.md` | 更新 | Unreleased に1行追記 |

## AC 充足確認

- [x] `POST /api/stripe/webhook` が Stripe-Signature ヘッダーで署名検証を行う
- [x] `subscriptions` が `stripe_subscription_id` をキーに冪等に upsert される
- [x] Pro 判定ルール（`active`/`trialing` または `current_period_end` 未来 → `pro`）を `plan` に反映

## 確認手順

### 自動テスト
```bash
npm run test:webhook
# → 7 passed / 0 failed