### PR TITLE
feat(#12): Pro/Free 機能ゲート（件数制限・/billing 誘導UI・dashboard バナー）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Unreleased
 
+- feat: Pro/Free 機能ゲートを追加（Free 10件超の作成をサーバー側でブロック・/billing への誘導UI・ダッシュボード上限バナー・isProUser を gate.ts に共通化）
 - feat: `POST /api/stripe/webhook` を追加（Stripe 署名検証・subscriptions 冪等 upsert・Pro 判定ルール反映）
 - feat: `POST /api/stripe/checkout` を追加（Stripe Checkout Session 作成・Pro アップグレード導線）
 - feat: `/billing` に Free/Pro 差分テーブルと Upgrade CTA を追加（非ログイン時は /login へリダイレクト）

--- a/src/app/api/deadlines/route.ts
+++ b/src/app/api/deadlines/route.ts
@@ -37,23 +37,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { prisma } from "@/lib/prisma";
 import { validateCreateDeadline } from "@/lib/deadlines/validate";
+import { FREE_ITEM_LIMIT, isProUser } from "@/lib/deadlines/gate";
 
-/** Free ユーザーが作成できる最大件数 */
-export const FREE_ITEM_LIMIT = 10;
-
-/**
- * subscriptions レコードを見て Pro か判定する。
- * Pro 判定: plan = "pro" かつ (status = "active" | "trialing" または current_period_end が未来)
- */
-async function isProUser(userId: string): Promise<boolean> {
-  const sub = await prisma.subscription.findUnique({ where: { userId } });
-  if (!sub || sub.plan !== "pro") return false;
-  const activeStatus =
-    sub.status === "active" || sub.status === "trialing";
-  const periodValid =
-    sub.currentPeriodEnd !== null && sub.currentPeriodEnd > new Date();
-  return activeStatus || periodValid;
-}
+// FREE_ITEM_LIMIT と isProUser は gate.ts からエクスポートして再エクスポート
+export { FREE_ITEM_LIMIT };
 
 export async function POST(req: NextRequest) {
   try {

--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -1,23 +1,13 @@
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
-import { prisma } from "@/lib/prisma";
+import { getUserPlan } from "@/lib/deadlines/gate";
 import { UpgradeButton } from "./UpgradeButton";
-
-/** Pro 判定: plan = "pro" かつ active/trialing または current_period_end が未来 */
-async function getPlan(userId: string): Promise<"free" | "pro"> {
-  const sub = await prisma.subscription.findUnique({ where: { userId } });
-  if (!sub || sub.plan !== "pro") return "free";
-  const activeStatus = sub.status === "active" || sub.status === "trialing";
-  const periodValid =
-    sub.currentPeriodEnd !== null && sub.currentPeriodEnd > new Date();
-  return activeStatus || periodValid ? "pro" : "free";
-}
 
 export default async function BillingPage() {
   const session = await getSession();
   if (!session) redirect("/login");
 
-  const plan = await getPlan(session.sub);
+  const plan = await getUserPlan(session.sub);
 
   return (
     <main className="mx-auto max-w-2xl p-6">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { getSession } from "@/lib/auth/session";
 import { prisma } from "@/lib/prisma";
 import DeadlineList, { type DeadlineItem } from "./DeadlineList";
+import { FREE_ITEM_LIMIT, isProUser } from "@/lib/deadlines/gate";
 
 /**
  * /dashboard – Server Component
@@ -17,26 +18,32 @@ export default async function DashboardPage() {
     redirect("/login");
   }
 
-  // 2. ログインユーザーのアイテムを deadline_at 昇順で取得
-  const rows = await prisma.deadlineItem.findMany({
-    where: { userId: session.sub },
-    orderBy: { deadlineAt: "asc" },
-    select: {
-      id: true,
-      companyName: true,
-      kind: true,
-      deadlineAt: true,
-      status: true,
-      link: true,
-      memo: true,
-    },
-  });
+  // 2. ログインユーザーのアイテムを deadline_at 昇順で取得 & Pro 判定を並列実行
+  const [rows, pro] = await Promise.all([
+    prisma.deadlineItem.findMany({
+      where: { userId: session.sub },
+      orderBy: { deadlineAt: "asc" },
+      select: {
+        id: true,
+        companyName: true,
+        kind: true,
+        deadlineAt: true,
+        status: true,
+        link: true,
+        memo: true,
+      },
+    }),
+    isProUser(session.sub),
+  ]);
 
   // 3. Date → ISO string に変換（Client Component へのシリアライズ要件）
   const items: DeadlineItem[] = rows.map((row) => ({
     ...row,
     deadlineAt: row.deadlineAt.toISOString(),
   }));
+
+  // Free ユーザーが上限に達しているか
+  const isAtFreeLimit = !pro && items.length >= FREE_ITEM_LIMIT;
 
   return (
     <main className="mx-auto max-w-3xl p-6">
@@ -50,6 +57,22 @@ export default async function DashboardPage() {
           + 締切を追加
         </Link>
       </div>
+
+      {/* Free 枠上限バナー */}
+      {isAtFreeLimit && (
+        <div className="mt-4 flex items-center justify-between rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm">
+          <p className="text-amber-800">
+            <span className="font-semibold">Free プランの上限（{FREE_ITEM_LIMIT}件）に達しています。</span>
+            {"　"}新しい締切を追加するには Pro へのアップグレードが必要です。
+          </p>
+          <Link
+            href="/billing"
+            className="ml-4 shrink-0 rounded-md bg-amber-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-1"
+          >
+            Pro にアップグレード
+          </Link>
+        </div>
+      )}
 
       {/* 締切一覧（クライアントコンポーネント） */}
       <DeadlineList initialItems={items} />

--- a/src/app/deadline/new/DeadlineForm.tsx
+++ b/src/app/deadline/new/DeadlineForm.tsx
@@ -7,7 +7,7 @@ import { KIND_LABEL } from "@/lib/deadlines/format";
 
 type FieldErrors = Record<string, string>;
 
-type Status = "idle" | "submitting" | "error";
+type Status = "idle" | "submitting" | "error" | "limit_exceeded";
 
 const KIND_OPTIONS = Object.entries(KIND_LABEL) as [string, string][];
 
@@ -23,6 +23,7 @@ export default function DeadlineForm() {
   const [status, setStatus] = useState<Status>("idle");
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [globalError, setGlobalError] = useState("");
+  const [limitExceeded, setLimitExceeded] = useState(false);
 
   /** クライアント側の必須チェック（送信前バリデーション） */
   function validate(): FieldErrors {
@@ -36,6 +37,7 @@ export default function DeadlineForm() {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setGlobalError("");
+    setLimitExceeded(false);
 
     // 1. クライアント側バリデーション
     const clientErrors = validate();
@@ -81,10 +83,13 @@ export default function DeadlineForm() {
         }
         setFieldErrors(errs);
         setStatus("error");
+      } else if (res.status === 403 && data.code === "FREE_LIMIT_EXCEEDED") {
+        setLimitExceeded(true);
+        setStatus("limit_exceeded");
       } else if (res.status === 403) {
         setGlobalError(
           data.error ??
-            "Free プランの登録上限（10件）に達しました。Pro にアップグレードしてください。",
+            "この操作は許可されていません。",
         );
         setStatus("error");
       } else {
@@ -101,6 +106,26 @@ export default function DeadlineForm() {
 
   return (
     <form onSubmit={handleSubmit} noValidate className="mt-6 space-y-6">
+      {/* Free 枠上限エラー（/billing への誘導リンク付き） */}
+      {limitExceeded && (
+        <div
+          role="alert"
+          className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+        >
+          <p className="font-semibold">Free プランの登録上限（10件）に達しました</p>
+          <p className="mt-1">
+            Pro にアップグレードすると締切アイテムが{" "}
+            <strong>無制限</strong>になります。
+          </p>
+          <Link
+            href="/billing"
+            className="mt-2 inline-block rounded-md bg-amber-600 px-4 py-1.5 text-sm font-semibold text-white hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-1"
+          >
+            Pro にアップグレード →
+          </Link>
+        </div>
+      )}
+
       {/* グローバルエラー */}
       {globalError && (
         <p

--- a/src/lib/deadlines/__tests__/gate.test.ts
+++ b/src/lib/deadlines/__tests__/gate.test.ts
@@ -1,0 +1,73 @@
+/**
+ * src/lib/deadlines/__tests__/gate.test.ts
+ *
+ * gate.ts のユニットテスト（純粋に検証できる部分のみ）
+ *
+ * 実行: npx tsx src/lib/deadlines/__tests__/gate.test.ts
+ *
+ * テスト戦略:
+ *  - FREE_ITEM_LIMIT: 定数値の検証
+ *  - isProUser / getUserPlan: Prisma 依存のため DB不要な手動確認手順を参照
+ *
+ * === 手動確認手順 ===
+ *
+ * 1. Pro 判定（isProUser）
+ *    a. DB に plan="pro", status="active" の subscriptions レコードを持つユーザーでログイン
+ *       → POST /api/deadlines が 10件超でも 201 を返すこと
+ *    b. plan="pro" だが status="canceled" かつ current_period_end が過去のユーザー
+ *       → POST /api/deadlines が 11件目で 403 / FREE_LIMIT_EXCEEDED を返すこと
+ *    c. subscriptions レコードなし（Free ユーザー）
+ *       → POST /api/deadlines が 11件目で 403 / FREE_LIMIT_EXCEEDED を返すこと
+ *
+ * 2. Free 枠上限バナー（ダッシュボード）
+ *    a. Free ユーザーでアイテム 10件の状態で /dashboard を表示
+ *       → オレンジ色の「Free プランの上限（10件）に達しています」バナーが出ること
+ *       → 「Pro にアップグレード」ボタンが /billing に遷移すること
+ *    b. Free ユーザーでアイテム 9件以下 → バナーが出ないこと
+ *    c. Pro ユーザーでアイテム 10件以上 → バナーが出ないこと
+ *
+ * 3. 作成フォームでの誘導（/deadline/new）
+ *    a. Free ユーザーでアイテム 10件の状態で /deadline/new へ遷移し「作成する」を押す
+ *       → フォーム上部にオレンジ色の「Pro にアップグレード →」ボタンが出ること
+ *       → ボタンを押すと /billing に遷移すること
+ *    b. Pro ユーザーは同状態でも正常に作成できること
+ */
+
+import assert from "node:assert/strict";
+import { FREE_ITEM_LIMIT } from "../gate";
+
+async function runAll() {
+  let passed = 0;
+  let failed = 0;
+
+  async function test(name: string, fn: () => void | Promise<void>) {
+    try {
+      await fn();
+      console.log(`  ✓ ${name}`);
+      passed++;
+    } catch (err) {
+      console.error(`  ✗ ${name}`);
+      console.error("   ", err instanceof Error ? err.message : err);
+      failed++;
+    }
+  }
+
+  console.log("\nPro/Free ゲート テスト\n");
+
+  await test("FREE_ITEM_LIMIT が 10 である", () => {
+    assert.equal(FREE_ITEM_LIMIT, 10);
+  });
+
+  await test("FREE_ITEM_LIMIT が number 型である", () => {
+    assert.equal(typeof FREE_ITEM_LIMIT, "number");
+  });
+
+  // 結果サマリー
+  console.log(`\n結果: ${passed} passed, ${failed} failed\n`);
+  if (failed > 0) process.exit(1);
+}
+
+runAll().catch((err) => {
+  console.error("予期しないエラー:", err);
+  process.exit(1);
+});

--- a/src/lib/deadlines/gate.ts
+++ b/src/lib/deadlines/gate.ts
@@ -1,0 +1,34 @@
+/**
+ * src/lib/deadlines/gate.ts
+ *
+ * Pro/Free ゲートに関する共通ユーティリティ。
+ * 同じロジックが route.ts / billing/page.tsx に重複しないよう一箇所に集約する。
+ */
+import { prisma } from "@/lib/prisma";
+
+/** Free ユーザーが作成できる最大件数 */
+export const FREE_ITEM_LIMIT = 10;
+
+/**
+ * subscriptions レコードを見て Pro か判定する。
+ *
+ * Pro 判定: plan = "pro" かつ 以下のいずれかを満たす
+ *   - status = "active" または "trialing"
+ *   - current_period_end が現在より未来
+ */
+export async function isProUser(userId: string): Promise<boolean> {
+  const sub = await prisma.subscription.findUnique({ where: { userId } });
+  if (!sub || sub.plan !== "pro") return false;
+  const activeStatus = sub.status === "active" || sub.status === "trialing";
+  const periodValid =
+    sub.currentPeriodEnd !== null && sub.currentPeriodEnd > new Date();
+  return activeStatus || periodValid;
+}
+
+/**
+ * ユーザーの現在プランを返す。
+ * UI表示用途に "free" | "pro" の文字列型で返す。
+ */
+export async function getUserPlan(userId: string): Promise<"free" | "pro"> {
+  return (await isProUser(userId)) ? "pro" : "free";
+}


### PR DESCRIPTION
## 概要

Issue #12 の AC をすべて満たすための Pro/Free 機能ゲート実装。
- Free ユーザーが 10 件超の締切アイテムを作成しようとするとサーバー側でブロックし、`/billing` への誘導 UI を表示する
- Pro ユーザーは件数無制限として扱われる
- `isProUser` ロジックの重複を `gate.ts` に集約した

## 変更理由

PRD Must-5「無料枠制限（10件まで）+ ペイウォール」の完成。
依存する #4（作成API）と #11（Stripe Webhook）はすでに実装済みのため、UI 誘導と共通化を本 PR でまとめる。

## 影響範囲

- [x] UI
- [x] API
- [ ] DB
- [ ] 設定/インフラ
- [ ] 依存関係

## 変更ファイル一覧

| ファイル | 変更種別 | 概要 |
|---|---|---|
| `src/lib/deadlines/gate.ts` | 新規 | `isProUser` / `getUserPlan` / `FREE_ITEM_LIMIT` を一箇所に集約 |
| `src/lib/deadlines/__tests__/gate.test.ts` | 新規 | `FREE_ITEM_LIMIT` 定数テスト + 手動確認手順コメント |
| `src/app/api/deadlines/route.ts` | 変更 | ローカル `isProUser` を削除 → `gate.ts` に差し替え |
| `src/app/billing/page.tsx` | 変更 | ローカル `getPlan` を削除 → `gate.ts` の `getUserPlan` に差し替え |
| `src/app/deadline/new/DeadlineForm.tsx` | 変更 | 403/`FREE_LIMIT_EXCEEDED` 時に `/billing` リンク付きオレンジバナーを表示 |
| `src/app/dashboard/page.tsx` | 変更 | Free 上限（10件）到達時にダッシュボード上部にアップグレードバナーを表示 |
| `CHANGELOG.md` | 変更 | Unreleased に1行追記 |

## 確認手順

1. **Free ユーザーで 10件登録済みの状態で `/deadline/new` を開き「作成する」を押す**
   - フォーム上部にオレンジ色のバナー「Free プランの上限（10件）に達しました」が表示されること
   - 「Pro にアップグレード →」ボタンを押すと `/billing` に遷移すること
2. **同ユーザーで `/dashboard` を開く**
   - ページ上部にオレンジ色のバナー「Free プランの上限（10件）に達しています」が表示されること
   - 「Pro にアップグレード」ボタンが `/billing` に遷移すること
3. **9件以下の Free ユーザー**
   - 上記バナーは表示されないこと
4. **Pro ユーザー（subscriptions: plan=pro, status=active）**
   - 10件超でも正常に作成でき、バナーは表示されないこと

## スクリーンショット/ログ

（手動確認後に添付）