### PR TITLE
fix(#12): limit_exceeded 時のボタンを disabled に変更、不要な再エクスポートを除去

### DIFF
--- a/src/app/api/deadlines/route.ts
+++ b/src/app/api/deadlines/route.ts
@@ -39,9 +39,6 @@ import { prisma } from "@/lib/prisma";
 import { validateCreateDeadline } from "@/lib/deadlines/validate";
 import { FREE_ITEM_LIMIT, isProUser } from "@/lib/deadlines/gate";
 
-// FREE_ITEM_LIMIT と isProUser は gate.ts からエクスポートして再エクスポート
-export { FREE_ITEM_LIMIT };
-
 export async function POST(req: NextRequest) {
   try {
     // 1. 認証確認

--- a/src/app/deadline/new/DeadlineForm.tsx
+++ b/src/app/deadline/new/DeadlineForm.tsx
@@ -103,6 +103,7 @@ export default function DeadlineForm() {
   }
 
   const isSubmitting = status === "submitting";
+  const isLimitExceeded = status === "limit_exceeded";
 
   return (
     <form onSubmit={handleSubmit} noValidate className="mt-6 space-y-6">
@@ -292,10 +293,10 @@ export default function DeadlineForm() {
       <div className="flex items-center gap-4">
         <button
           type="submit"
-          disabled={isSubmitting}
+          disabled={isSubmitting || isLimitExceeded}
           className="rounded-lg bg-blue-600 px-6 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {isSubmitting ? "保存中..." : "作成する"}
+          {isSubmitting ? "保存中..." : isLimitExceeded ? "上限に達しています" : "作成する"}
         </button>
         <Link
           href="/dashboard"


### PR DESCRIPTION
- DeadlineForm.tsx: isLimitExceeded フラグを追加。上限到達後に
  ボタンを disabled にし、ラベルを「上限に達しています」に変更。
  再押しによるバナーちらつきを防止。
- route.ts: 不要な export { FREE_ITEM_LIMIT } を削除。
  定数の正規ソースは gate.ts のみとする。