### PR TITLE
feat: /billing/success と /billing/cancel の着地ページを整備 (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Unreleased
 
+- feat: `/billing/success` と `/billing/cancel` の着地ページを整備（Pro有効化メッセージ・/dashboard 導線 / キャンセルメッセージ・/billing 導線）
 - feat: Pro/Free 機能ゲートを追加（Free 10件超の作成をサーバー側でブロック・/billing への誘導UI・ダッシュボード上限バナー・isProUser を gate.ts に共通化）
 - feat: `POST /api/stripe/webhook` を追加（Stripe 署名検証・subscriptions 冪等 upsert・Pro 判定ルール反映）
 - feat: `POST /api/stripe/checkout` を追加（Stripe Checkout Session 作成・Pro アップグレード導線）

--- a/docs/MVP_BACKLOG.md
+++ b/docs/MVP_BACKLOG.md
@@ -141,8 +141,8 @@
 
 - 目的: Stripeリダイレクト後の迷子を防ぐ
 - AC:
-  - [ ] success で「Pro有効化中/完了」メッセージと /dashboard 導線がある
-  - [ ] cancel で「課金キャンセル」メッセージと /billing 導線がある
+  - [x] success で「Pro有効化中/完了」メッセージと /dashboard 導線がある
+  - [x] cancel で「課金キャンセル」メッセージと /billing 導線がある
 - 優先度: P1
 - 依存関係: #10
 - 推定: S

--- a/src/app/billing/cancel/page.tsx
+++ b/src/app/billing/cancel/page.tsx
@@ -1,14 +1,41 @@
 import Link from "next/link";
 
+/**
+ * /billing/cancel – Stripe Checkout キャンセル後のリダイレクト先
+ *
+ * ACチェック:
+ * - "課金キャンセル" メッセージを表示
+ * - /billing への導線を提供
+ */
 export default function BillingCancelPage() {
   return (
     <main className="mx-auto max-w-md p-6">
-      <h1 className="text-xl font-semibold">課金をキャンセルしました</h1>
-      <p className="mt-2 text-slate-700">必要になったらいつでもアップグレードできます。</p>
-      <div className="mt-6">
-        <Link className="underline" href="/billing">
-          /billing に戻る
-        </Link>
+      <div className="flex flex-col items-center text-center">
+        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-slate-100 text-3xl">
+          ℹ️
+        </div>
+        <h1 className="mt-4 text-2xl font-bold text-slate-900">
+          課金をキャンセルしました
+        </h1>
+        <p className="mt-3 text-slate-600">
+          購入はキャンセルされました。カードへの請求はありません。
+          <br />
+          必要になったらいつでも Pro にアップグレードできます。
+        </p>
+        <div className="mt-8 flex flex-col items-center gap-3">
+          <Link
+            href="/billing"
+            className="rounded-md bg-slate-900 px-5 py-2.5 text-sm font-medium text-white hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
+          >
+            プラン・お支払いページへ戻る
+          </Link>
+          <Link
+            href="/dashboard"
+            className="text-sm text-slate-500 underline hover:text-slate-700"
+          >
+            ダッシュボードへ
+          </Link>
+        </div>
       </div>
     </main>
   );

--- a/src/app/billing/success/page.tsx
+++ b/src/app/billing/success/page.tsx
@@ -1,14 +1,38 @@
 import Link from "next/link";
 
+/**
+ * /billing/success – Stripe Checkout 成功後のリダイレクト先
+ *
+ * ACチェック:
+ * - "Pro有効化中/完了" メッセージを表示
+ * - /dashboard への導線を提供
+ */
 export default function BillingSuccessPage() {
   return (
     <main className="mx-auto max-w-md p-6">
-      <h1 className="text-xl font-semibold">購入が完了しました</h1>
-      <p className="mt-2 text-slate-700">Proの有効化を確認中です。</p>
-      <div className="mt-6">
-        <Link className="underline" href="/dashboard">
-          ダッシュボードへ
-        </Link>
+      <div className="flex flex-col items-center text-center">
+        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-green-100 text-3xl">
+          ✅
+        </div>
+        <h1 className="mt-4 text-2xl font-bold text-slate-900">
+          Pro プランへようこそ！
+        </h1>
+        <p className="mt-3 text-slate-600">
+          Pro が有効化されました。締切を無制限に登録して、
+          <br />
+          72h / 24h / 3h 前のメール通知をご利用いただけます。
+        </p>
+        <p className="mt-2 text-sm text-slate-400">
+          ※ 反映に数秒かかる場合があります。有効化中はしばらくお待ちください。
+        </p>
+        <div className="mt-8">
+          <Link
+            href="/dashboard"
+            className="rounded-md bg-slate-900 px-5 py-2.5 text-sm font-medium text-white hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
+          >
+            ダッシュボードへ
+          </Link>
+        </div>
       </div>
     </main>
   );


### PR DESCRIPTION
## 概要

Stripe Checkout のリダイレクト先である `/billing/success` と `/billing/cancel` を整備し、
ユーザーが迷子にならないよう導線を明確にした。

関連 Issue: #13

## 変更理由

Stripe Checkout 成功・キャンセル後のリダイレクト先が最低限のテキストのみで、
ユーザーが次に何をすべきか分からなかった。AC に従い、メッセージと導線を整備した。

## 影響範囲

- [x] UI
- [ ] API
- [ ] DB
- [ ] 設定/インフラ
- [ ] 依存関係

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/app/billing/success/page.tsx` | Pro有効化完了メッセージ・反映待ち補足・/dashboard CTA を追加 |
| `src/app/billing/cancel/page.tsx` | 課金キャンセルメッセージ・請求なし明記・/billing 戻りCTA・/dashboard サブリンクを追加 |
| `CHANGELOG.md` | Unreleased に1行追記 |
| `docs/MVP_BACKLOG.md` | #13 の AC を [x] に更新 |

## AC チェック

- [x] success で「Pro有効化中/完了」メッセージと /dashboard 導線がある
- [x] cancel で「課金キャンセル」メッセージと /billing 導線がある

## 確認手順

1. `npm run dev` でローカル起動
2. `/billing/success` へ直接アクセス → 「Pro プランへようこそ！」が表示され「ダッシュボードへ」ボタンで `/dashboard` に遷移できること
3. `/billing/cancel` へ直接アクセス → 「課金をキャンセルしました」が表示され「プラン・お支払いページへ戻る」ボタンで `/billing` に遷移できること
4. Stripe のテストモードで実際に Checkout → success / cancel のリダイレクトが正しく動くこと（`stripe listen` 起動中）

## スクリーンショット/ログ

（任意）

## リスクとロールバック

- リスク: なし（静的ページの見た目変更のみ、APIや DB に影響なし）
- ロールバック: `git revert` またはブランチ削除で即時巻き戻し可能