### PR TITLE
feat: Stripe Customer Portal API（解約/支払い方法変更）#14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Unreleased
 
+- feat: `POST /api/stripe/portal` を追加（Stripe Customer Portal Session 作成・解約/支払い方法変更を委譲）、`/billing` にProユーザー向け「管理画面へ」ボタンを追加
 - feat: `/billing/success` と `/billing/cancel` の着地ページを整備（Pro有効化メッセージ・/dashboard 導線 / キャンセルメッセージ・/billing 導線）
 - feat: Pro/Free 機能ゲートを追加（Free 10件超の作成をサーバー側でブロック・/billing への誘導UI・ダッシュボード上限バナー・isProUser を gate.ts に共通化）
 - feat: `POST /api/stripe/webhook` を追加（Stripe 署名検証・subscriptions 冪等 upsert・Pro 判定ルール反映）

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:deadlines": "npx tsx src/lib/deadlines/__tests__/deadlines.test.ts",
     "test:format": "npx tsx src/lib/deadlines/__tests__/format.test.ts",
     "test:stripe": "npx tsx src/lib/stripe/__tests__/stripe.test.ts",
-    "test:webhook": "npx tsx src/lib/stripe/__tests__/webhook.test.ts"
+    "test:webhook": "npx tsx src/lib/stripe/__tests__/webhook.test.ts",
+    "test:portal": "npx tsx src/lib/stripe/__tests__/portal.test.ts"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.5.0",

--- a/src/app/api/stripe/portal/route.ts
+++ b/src/app/api/stripe/portal/route.ts
@@ -1,0 +1,85 @@
+/**
+ * POST /api/stripe/portal
+ *
+ * Stripe Customer Portal Session を作成し、ポータルページの URL を返すAPI。
+ * Pro ユーザーが解約・支払い方法変更などをStripeに委譲するための導線。
+ *
+ * 認証:
+ *  - セッションクッキーが必要（未ログインは 401）
+ *
+ * 前提:
+ *  - subscriptions テーブルに stripe_customer_id が存在することが必要
+ *  - stripe_customer_id が未設定の場合は 400 を返す（Checkout を先に完了させる）
+ *
+ * 環境変数:
+ *  - STRIPE_SECRET_KEY: Stripe シークレットキー（必須）
+ *  - APP_URL: リダイレクト先の基底URL（必須）
+ *
+ * リクエスト: なし（Body 不要）
+ *
+ * レスポンス:
+ *  - { ok: true, url: string }  200  Stripe Customer Portal URL
+ *  - { error: string }          400  stripe_customer_id 未設定
+ *  - { error: string }          401  未認証
+ *  - { error: string }          405  GET不可
+ *  - { error: string }          500  サーバーエラー
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { getStripe } from "@/lib/stripe";
+import { prisma } from "@/lib/prisma";
+
+/** GET は許可しない */
+export function GET() {
+  return NextResponse.json(
+    { error: "このエンドポイントは POST のみ受け付けます。" },
+    { status: 405 },
+  );
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    // 1. 認証確認
+    const session = await getSession(req);
+    if (!session) {
+      return NextResponse.json(
+        { error: "ログインが必要です" },
+        { status: 401 },
+      );
+    }
+    const userId = session.sub;
+
+    // 2. APP_URL チェック
+    const appUrl = process.env.APP_URL;
+    if (!appUrl) {
+      throw new Error("APP_URL is not set. Add it to .env");
+    }
+
+    // 3. stripe_customer_id を取得
+    const subscription = await prisma.subscription.findUnique({
+      where: { userId },
+      select: { stripeCustomerId: true },
+    });
+
+    if (!subscription?.stripeCustomerId) {
+      return NextResponse.json(
+        { error: "Stripe カスタマー情報が見つかりません。先にプランのアップグレードをおこなってください。" },
+        { status: 400 },
+      );
+    }
+
+    // 4. Customer Portal Session 作成
+    const portalSession = await getStripe().billingPortal.sessions.create({
+      customer: subscription.stripeCustomerId,
+      return_url: `${appUrl}/billing`,
+    });
+
+    return NextResponse.json({ ok: true, url: portalSession.url });
+  } catch (err) {
+    console.error("[POST /api/stripe/portal] unexpected error:", err);
+    return NextResponse.json(
+      { error: "サーバーエラーが発生しました" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/billing/PortalButton.tsx
+++ b/src/app/billing/PortalButton.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Stripe Customer Portal へ遷移するボタン（Pro ユーザー向け）
+ * 解約・支払い方法変更などをStripeに委譲する。
+ */
+export function PortalButton() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handlePortal() {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/stripe/portal", { method: "POST" });
+      const data = await res.json().catch(() => null);
+
+      if (!res.ok || !data?.url) {
+        setError(data?.error ?? "エラーが発生しました。再試行してください。");
+        return;
+      }
+
+      // Stripe Customer Portal へリダイレクト
+      window.location.href = data.url;
+    } catch {
+      setError("ネットワークエラーが発生しました。再試行してください。");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div>
+      {error && (
+        <p className="mb-3 rounded bg-red-50 px-4 py-2 text-sm text-red-600" role="alert">
+          {error}
+        </p>
+      )}
+      <button
+        className="rounded border border-slate-300 bg-white px-6 py-3 font-semibold text-slate-700 transition hover:bg-slate-50 disabled:opacity-60"
+        disabled={loading}
+        onClick={handlePortal}
+        type="button"
+      >
+        {loading ? "処理中..." : "管理画面へ（解約・支払い方法変更）"}
+      </button>
+    </div>
+  );
+}

--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { getUserPlan } from "@/lib/deadlines/gate";
 import { UpgradeButton } from "./UpgradeButton";
+import { PortalButton } from "./PortalButton";
 
 export default async function BillingPage() {
   const session = await getSession();
@@ -56,9 +57,12 @@ export default async function BillingPage() {
       {/* CTA */}
       <div className="mt-8">
         {plan === "pro" ? (
-          <p className="text-slate-500">
-            プランの管理・解約は Stripe 管理画面からおこなえます。
-          </p>
+          <div className="space-y-3">
+            <p className="text-sm text-slate-500">
+              解約・支払い方法の変更は Stripe 管理画面からおこなえます。
+            </p>
+            <PortalButton />
+          </div>
         ) : (
           <UpgradeButton />
         )}

--- a/src/lib/stripe/__tests__/portal.test.ts
+++ b/src/lib/stripe/__tests__/portal.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Stripe Customer Portal API 最小テスト
+ * 実行: npm run test:portal
+ *
+ * テスト戦略:
+ *  - APP_URL 未設定時に Error が throw されるか
+ *  - STRIPE_SECRET_KEY 未設定時に Error が throw されるか
+ *  - stripe_customer_id が null の場合に 400 相当のエラーを返すロジック確認
+ *  （実際の billingPortal.sessions.create は手動確認とする: Stripe Dashboard にPortal設定が必要）
+ */
+
+import "dotenv/config";
+import assert from "node:assert/strict";
+
+/** portal route 内の必須環境変数チェックと同等のロジック */
+function requireEnv(key: string): string {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`${key} is not set. Add it to .env`);
+  }
+  return value;
+}
+
+/** stripe_customer_id が存在しない場合の応答ロジック（route から抽出） */
+function resolvePortalError(stripeCustomerId: string | null | undefined): string | null {
+  if (!stripeCustomerId) {
+    return "Stripe カスタマー情報が見つかりません。先にプランのアップグレードをおこなってください。";
+  }
+  return null;
+}
+
+async function runAll() {
+  let passed = 0;
+  let failed = 0;
+
+  async function test(name: string, fn: () => void | Promise<void>) {
+    try {
+      await fn();
+      console.log(`  ✓ ${name}`);
+      passed++;
+    } catch (err) {
+      console.error(`  ✗ ${name}`);
+      console.error("   ", err instanceof Error ? err.message : err);
+      failed++;
+    }
+  }
+
+  console.log("\nStripe Customer Portal テスト\n");
+
+  await test("requireEnv: 未設定の変数は Error を throw する", () => {
+    const missingKey = "__NONEXISTENT_PORTAL_ENV_VAR__";
+    delete process.env[missingKey];
+    assert.throws(
+      () => requireEnv(missingKey),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.ok(err.message.includes(missingKey));
+        return true;
+      },
+    );
+  });
+
+  await test("requireEnv: 設定済みの変数は値を返す", () => {
+    const key = "__TEST_PORTAL_ENV_VAR__";
+    process.env[key] = "http://localhost:3000";
+    const val = requireEnv(key);
+    assert.equal(val, "http://localhost:3000");
+    delete process.env[key];
+  });
+
+  await test("resolvePortalError: stripeCustomerId が null → エラーメッセージを返す", () => {
+    const err = resolvePortalError(null);
+    assert.ok(err !== null);
+    assert.ok(err.includes("アップグレード"));
+  });
+
+  await test("resolvePortalError: stripeCustomerId が undefined → エラーメッセージを返す", () => {
+    const err = resolvePortalError(undefined);
+    assert.ok(err !== null);
+    assert.ok(err.includes("アップグレード"));
+  });
+
+  await test("resolvePortalError: stripeCustomerId が設定済み → null（エラーなし）", () => {
+    const err = resolvePortalError("cus_test_12345");
+    assert.equal(err, null);
+  });
+
+  await test("STRIPE_SECRET_KEY 未設定は Error を throw する（portal route も同じ依存）", () => {
+    const originalKey = process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_SECRET_KEY;
+    try {
+      assert.throws(() => {
+        if (!process.env.STRIPE_SECRET_KEY) {
+          throw new Error("STRIPE_SECRET_KEY is not set. Add it to .env");
+        }
+      });
+    } finally {
+      if (originalKey !== undefined) {
+        process.env.STRIPE_SECRET_KEY = originalKey;
+      }
+    }
+  });
+
+  console.log(`\n${passed} passed / ${failed} failed\n`);
+  if (failed > 0) process.exit(1);
+}
+
+runAll().catch((err) => {
+  console.error("テスト実行エラー:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## 概要

Stripe Customer Portal を利用して、Proユーザーが解約・支払い方法変更をStripe側で完結できる仕組みを実装する。

## 変更理由

- Issue #14: サブスク運用の最低限（解約/カード変更）をStripeに委譲する
- 手動でサブスク管理する運用コストをゼロにする

## 影響範囲

- [x] UI（`/billing` に「管理画面へ」ボタン追加）
- [x] API（`POST /api/stripe/portal` 新規）
- [ ] DB
- [ ] 設定/インフラ
- [ ] 依存関係

## 確認手順

1. Stripe Dashboard > Billing > Customer portal で「Activate test link」を有効化（初回のみ）
2. `.env` に `STRIPE_SECRET_KEY` / `APP_URL` が設定済みであることを確認
3. ローカル起動: `npm run dev`
4. Proユーザー（Stripe Checkoutで購入済み）で `/billing` を開く
5.「管理画面へ（解約・支払い方法変更）」ボタンが表示されることを確認
6. ボタンをクリック → Stripe Customer Portal ページへ遷移することを確認
7. Freeユーザーでは上記ボタンが表示されず、「Pro にアップグレード」ボタンが表示されることを確認
8. `npm run test:portal` → 6 passed / 0 failed を確認

## スクリーンショット/ログ

（省略 — 手動確認でStripe側URLへ遷移を目視確認）

## AC確認

- [x] `POST /api/stripe/portal` が Portal Session を作成できる
- [x] `/billing` から「管理画面へ」導線がある（Proユーザー向け）