### PR TITLE
fix: Stripe Checkout の metadata を subscription_data に移動（#14 バグ修正）

### DIFF
--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -73,8 +73,12 @@ export async function POST(req: NextRequest) {
           quantity: 1,
         },
       ],
-      metadata: {
-        userId,
+      // subscription_data.metadata に設定することで
+      // Subscription オブジェクトに userId が引き継がれ、webhook で参照できる
+      subscription_data: {
+        metadata: {
+          userId,
+        },
       },
       success_url: `${appUrl}/billing/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${appUrl}/billing/cancel`,


### PR DESCRIPTION
## 概要

`POST /api/stripe/checkout` で `metadata: { userId }` を `subscription_data.metadata` に移動する。

Checkout Session の `metadata` は Subscription オブジェクトに引き継がれないため、
webhook（`customer.subscription.created`）受信時に `userId` が取得できず
`subscriptions` テーブルへの upsert が無言でスキップされていた。

## 変更理由

- #14 の動作確認中に `subscriptions` テーブルが空のままになる問題を発見
- webhook が 200 を返しているにもかかわらず DB に書き込まれない → `userId` が `null` でスキップされていた
- `subscription_data.metadata` に設定することで Subscription オブジェクトに引き継がれ、upsert が正常に動作する

## 影響範囲

- [x] API（`POST /api/stripe/checkout` の Session 作成パラメータ変更）
- [ ] UI
- [ ] DB
- [ ] 設定/インフラ
- [ ] 依存関係

## 確認手順

1. `stripe listen --forward-to localhost:3000/api/stripe/webhook` を起動
2. `/billing` から「Pro にアップグレード」→ Checkout をテストカードで通過
3. `stripe` ターミナルに `customer.subscription.created → 200` が出ることを確認
4. `npx prisma studio` で `subscriptions` テーブルに `plan=pro` のレコードが作成されることを確認

## スクリーンショット/ログ
