### PR TITLE
refactor: portal route の APP_URL チェックを getRequiredEnv に統一

### DIFF
--- a/src/app/api/stripe/portal/route.ts
+++ b/src/app/api/stripe/portal/route.ts
@@ -29,6 +29,14 @@ import { getSession } from "@/lib/auth/session";
 import { getStripe } from "@/lib/stripe";
 import { prisma } from "@/lib/prisma";
 
+function getRequiredEnv(key: string): string {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`${key} is not set. Add it to .env`);
+  }
+  return value;
+}
+
 /** GET は許可しない */
 export function GET() {
   return NextResponse.json(
@@ -50,10 +58,7 @@ export async function POST(req: NextRequest) {
     const userId = session.sub;
 
     // 2. APP_URL チェック
-    const appUrl = process.env.APP_URL;
-    if (!appUrl) {
-      throw new Error("APP_URL is not set. Add it to .env");
-    }
+    const appUrl = getRequiredEnv("APP_URL");
 
     // 3. stripe_customer_id を取得
     const subscription = await prisma.subscription.findUnique({


### PR DESCRIPTION
## 概要

`POST /api/stripe/portal` 内の `APP_URL` 取得ロジックを `getRequiredEnv` ヘルパーに統一する。

## 変更理由

- `checkout/route.ts` では `getRequiredEnv` を使っているが、`portal/route.ts` では
  `process.env.APP_URL` を直接参照 + 手動チェックで書いており、パターンが不統一だった
- 機能的な差異はないが、可読性と保守性のために揃える

## 影響範囲

- [x] API（`POST /api/stripe/portal` の内部実装のみ、外部仕様は変更なし）
- [ ] UI
- [ ] DB
- [ ] 設定/インフラ
- [ ] 依存関係

## 確認手順

1. `npm run test:portal` → 6 passed / 0 failed
2. 動作変化なし（外部から見た挙動は同一）

## スクリーンショット/ログ

なし（リファクタリングのみ）