### PR TITLE
feat: #15 通知Cron（POST /api/cron/notify）を実装 — CRON_SECRET保護・重複防止・sent/failed更新

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,10 @@ STRIPE_PRICE_ID=
 # ローカル: stripe listen --forward-to localhost:3000/api/stripe/webhook で取得した whsec_xxx
 # 本番: Stripe Dashboard > Developers > Webhooks > エンドポイント詳細 > Signing secret
 STRIPE_WEBHOOK_SECRET=
+
+# Cron（通知）
+# POST /api/cron/notify を保護するシークレット
+# 生成例: openssl rand -base64 32
+# Vercel: 環境変数 CRON_SECRET に設定する (vercel.json の crons から自動呼び出し)
+# ローカル手動確認: curl -X POST http://localhost:3000/api/cron/notify -H "Authorization: Bearer <CRON_SECRET>"
+CRON_SECRET=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Unreleased
 
+- feat: `POST /api/cron/notify` を追加（CRON_SECRET 保護・締切前メール通知 Free=24h/Pro=72h/24h/3h・notification_deliveries の冪等 upsert で重複防止・成否で sent/failed 更新）
 - feat: `POST /api/stripe/portal` を追加（Stripe Customer Portal Session 作成・解約/支払い方法変更を委譲）、`/billing` にProユーザー向け「管理画面へ」ボタンを追加
 - feat: `/billing/success` と `/billing/cancel` の着地ページを整備（Pro有効化メッセージ・/dashboard 導線 / キャンセルメッセージ・/billing 導線）
 - feat: Pro/Free 機能ゲートを追加（Free 10件超の作成をサーバー側でブロック・/billing への誘導UI・ダッシュボード上限バナー・isProUser を gate.ts に共通化）

--- a/src/app/api/cron/notify/route.ts
+++ b/src/app/api/cron/notify/route.ts
@@ -1,0 +1,98 @@
+/**
+ * POST /api/cron/notify
+ *
+ * 通知 Cron エンドポイント（ADR 0004 / 0005 準拠）
+ *
+ * 処理フロー:
+ *  1. CRON_SECRET で認証（Authorization: Bearer <secret>）
+ *  2. 現在ウィンドウ内の通知対象を抽出し、notification_deliveries を upsert
+ *  3. status=scheduled のレコードにメール送信し、成否で status を更新する
+ *
+ * 環境変数:
+ *  CRON_SECRET  Cron 呼び出し用シークレット（必須）
+ *               Vercel の環境変数 / ローカルは .env に設定
+ *
+ * 呼び出し方（例）:
+ *  curl -X POST http://localhost:3000/api/cron/notify \
+ *    -H "Authorization: Bearer <CRON_SECRET>"
+ *
+ * レスポンス:
+ *  { ok: true, result: NotifyResult }   200  正常完了
+ *  { error: string }                    401  認証失敗
+ *  { error: string }                    500  サーバーエラー
+ *
+ * Vercel Cron 設定（vercel.json）:
+ *  "crons": [{ "path": "/api/cron/notify", "schedule": "* /10 * * * *" }]
+ *  ※ schedule: 10分間隔（"星印/10 * * * *"形式、JSDoc上の都合でスペース挿入済み）
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { findAndDeliverNotifications } from "@/lib/notifications/notify";
+
+/** GET は許可しない */
+export function GET() {
+  return NextResponse.json(
+    { error: "このエンドポイントは POST のみ受け付けます。" },
+    { status: 405 },
+  );
+}
+
+export async function POST(req: NextRequest) {
+  // 1. CRON_SECRET 認証
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    console.error("[cron/notify] CRON_SECRET が設定されていません");
+    return NextResponse.json(
+      { error: "サーバー設定エラー: CRON_SECRET が未設定です" },
+      { status: 500 },
+    );
+  }
+
+  const authHeader = req.headers.get("authorization") ?? "";
+  const token = authHeader.startsWith("Bearer ")
+    ? authHeader.slice("Bearer ".length).trim()
+    : "";
+
+  // タイミング攻撃対策: 長さが違っても timingSafeEqual 相当の比較を行う
+  if (!timingSafeEqual(token, cronSecret)) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401 },
+    );
+  }
+
+  // 2. 通知処理
+  try {
+    const result = await findAndDeliverNotifications();
+    console.log("[cron/notify] 完了", result);
+    return NextResponse.json({ ok: true, result });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[cron/notify] エラー:", message);
+    return NextResponse.json(
+      { error: `通知処理エラー: ${message}` },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * タイミング攻撃を緩和するための文字列比較。
+ * Node.js の crypto.timingSafeEqual は EdgeRuntime では使えないため、
+ * 長さを統一してから XOR 比較する簡易実装を使う。
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    // 長さが違う場合も全体を走査してタイミングを均一化
+    let diff = 0;
+    for (let i = 0; i < Math.max(a.length, b.length); i++) {
+      diff |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
+    }
+    return false; // 長さ不一致は必ず false
+  }
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/src/lib/notifications/__tests__/notify.test.ts
+++ b/src/lib/notifications/__tests__/notify.test.ts
@@ -1,0 +1,164 @@
+/**
+ * src/lib/notifications/__tests__/notify.test.ts
+ *
+ * 通知ロジックのユニットテスト（DB・メール送信不要な純粋関数のみ）
+ *
+ * 実行: npx tsx src/lib/notifications/__tests__/notify.test.ts
+ *
+ * テスト対象:
+ *  - offsetLabel: オフセット分数 → 表示ラベルの変換
+ *  - buildNotificationHtml: メール件名・HTML・テキストの生成
+ *  - 定数: OFFSETS_FREE / OFFSETS_PRO / CRON_WINDOW_MINUTES
+ *
+ * === 手動確認手順（DB 結合が必要なもの） ===
+ *
+ * 1. CRON_SECRET 認証テスト
+ *    a. CRON_SECRET を .env に設定した状態で以下を実行:
+ *       curl -X POST http://localhost:3000/api/cron/notify \
+ *         -H "Authorization: Bearer <正しいシークレット>"
+ *       → { ok: true, result: { processed, sent, failed, skipped } } が返ること
+ *    b. シークレットを間違えた場合:
+ *       → 401 Unauthorized が返ること
+ *    c. CRON_SECRET 未設定の場合:
+ *       → 500 が返ること
+ *
+ * 2. 重複防止テスト
+ *    a. 同一 (deadline_item_id, offset_minutes) で 2 回 Cron を実行する
+ *       → 2 回目は notification_delivery.status が変わらず、sent 数が 0 になること
+ *
+ * 3. Free プラン通知テスト
+ *    a. subscriptions レコードなし（Free ユーザー）に対して Cron を実行する
+ *       → offset_minutes=1440（24h）の通知のみ送信されること
+ *       → pro オフセット（4320/180）の通知が作成されないこと
+ *
+ * 4. Pro プラン通知テスト
+ *    a. plan="pro", status="active" のユーザーに対して Cron を実行する
+ *       → offset_minutes=4320/1440/180 の通知がそれぞれ送信されること
+ *
+ * 5. 送信失敗テスト
+ *    a. EMAIL_PROVIDER=resend かつ無効な RESEND_API_KEY を設定して Cron を実行する
+ *       → notification_delivery.status が "failed" になること
+ *       → notification_delivery.error にエラーメッセージが入ること
+ *
+ * 6. ウィンドウ外スキップテスト
+ *    a. deadline_at が 100 時間後のアイテムに対して Cron を実行する
+ *       → 通知が作成されないこと（どのオフセットもウィンドウ外）
+ */
+
+import assert from "node:assert/strict";
+import {
+  offsetLabel,
+  buildNotificationHtml,
+  OFFSETS_FREE,
+  OFFSETS_PRO,
+  CRON_WINDOW_MINUTES,
+} from "../notify";
+
+async function runAll() {
+  let passed = 0;
+  let failed = 0;
+
+  async function test(name: string, fn: () => void | Promise<void>) {
+    try {
+      await fn();
+      console.log(`  ✓ ${name}`);
+      passed++;
+    } catch (err) {
+      console.error(`  ✗ ${name}`);
+      console.error("   ", err instanceof Error ? err.message : err);
+      failed++;
+    }
+  }
+
+  console.log("\n通知ロジック テスト\n");
+
+  // --- 定数チェック ---
+  await test("OFFSETS_FREE は [1440] である", () => {
+    assert.deepEqual(OFFSETS_FREE, [1440]);
+  });
+
+  await test("OFFSETS_PRO は [4320, 1440, 180] である", () => {
+    assert.deepEqual(OFFSETS_PRO, [4320, 1440, 180]);
+  });
+
+  await test("CRON_WINDOW_MINUTES は 10 である", () => {
+    assert.equal(CRON_WINDOW_MINUTES, 10);
+  });
+
+  // --- offsetLabel ---
+  await test("offsetLabel(4320) は '72時間' を返す", () => {
+    assert.equal(offsetLabel(4320), "72時間");
+  });
+
+  await test("offsetLabel(1440) は '24時間' を返す", () => {
+    assert.equal(offsetLabel(1440), "24時間");
+  });
+
+  await test("offsetLabel(180) は '3時間' を返す", () => {
+    assert.equal(offsetLabel(180), "3時間");
+  });
+
+  await test("offsetLabel(60) は '60分' を返す（未定義値のフォールバック）", () => {
+    assert.equal(offsetLabel(60), "60分");
+  });
+
+  // --- buildNotificationHtml ---
+  await test("buildNotificationHtml: subject に企業名・オフセットラベルが含まれる", () => {
+    const result = buildNotificationHtml({
+      companyName: "テスト株式会社",
+      kind: "es",
+      deadlineAt: new Date("2026-03-18T15:00:00Z"), // UTC → JST 2026-03-19 00:00
+      offsetMinutes: 1440,
+      appUrl: "http://localhost:3000",
+    });
+    assert.ok(result.subject.includes("テスト株式会社"), "subject に企業名がない");
+    assert.ok(result.subject.includes("24時間"), "subject にオフセットラベルがない");
+    assert.ok(result.subject.includes("ES"), "subject に種別がない");
+  });
+
+  await test("buildNotificationHtml: html にダッシュボードリンクが含まれる", () => {
+    const result = buildNotificationHtml({
+      companyName: "テスト株式会社",
+      kind: "interview",
+      deadlineAt: new Date("2026-03-18T15:00:00Z"),
+      offsetMinutes: 180,
+      appUrl: "https://example.com",
+    });
+    assert.ok(result.html.includes("https://example.com/dashboard"), "html にダッシュボードリンクがない");
+    assert.ok(result.html.includes("3時間"), "html にオフセットラベルがない");
+  });
+
+  await test("buildNotificationHtml: text が生成される", () => {
+    const result = buildNotificationHtml({
+      companyName: "テスト株式会社",
+      kind: "briefing",
+      deadlineAt: new Date("2026-03-18T15:00:00Z"),
+      offsetMinutes: 4320,
+      appUrl: "http://localhost:3000",
+    });
+    assert.ok(result.text.length > 0, "text が空");
+    assert.ok(result.text.includes("72時間"), "text にオフセットラベルがない");
+  });
+
+  await test("buildNotificationHtml: deadline_at の JST 表示が正しい", () => {
+    // UTC 2026-03-18 15:00:00 → JST 2026-03-19 00:00
+    const result = buildNotificationHtml({
+      companyName: "テスト株式会社",
+      kind: "other",
+      deadlineAt: new Date("2026-03-18T15:00:00Z"),
+      offsetMinutes: 1440,
+      appUrl: "http://localhost:3000",
+    });
+    // JST: 2026-03-19 00:00 が html に含まれること
+    assert.ok(result.html.includes("2026-03-19 00:00"), `JST 変換が正しくない: ${result.html}`);
+  });
+
+  // --- まとめ ---
+  console.log(`\n結果: ${passed} 件成功, ${failed} 件失敗\n`);
+  if (failed > 0) process.exit(1);
+}
+
+runAll().catch((err) => {
+  console.error("テスト実行エラー:", err);
+  process.exit(1);
+});

--- a/src/lib/notifications/notify.ts
+++ b/src/lib/notifications/notify.ts
@@ -1,0 +1,225 @@
+/**
+ * src/lib/notifications/notify.ts
+ *
+ * 通知 Cron のコアロジック（ADR 0005 準拠）
+ *
+ * 設計方針:
+ *  - Free=24h前 (offset_minutes=1440)、Pro=72h/24h/3h前 (offset_minutes=4320/1440/180)
+ *  - Cron 実行ごとに「ウィンドウ内に scheduled_for が入る対象」を抽出する
+ *  - 送信前に notification_deliveries を upsert（一意制約で重複作成を防止）
+ *  - status=scheduled のレコードのみを実際に送信し、成否で sent/failed に更新する
+ *
+ * ウィンドウ設計:
+ *  - scheduled_for = deadline_at - offset_minutes
+ *  - ウィンドウ: now() - CRON_WINDOW_MINUTES <= scheduled_for <= now() + CRON_WINDOW_MINUTES
+ *  - Cron 間隔（5〜10分）に合わせて取りこぼしをリカバリする
+ */
+
+import { prisma } from "@/lib/prisma";
+import { sendEmail } from "@/lib/mailer";
+import { isProUser } from "@/lib/deadlines/gate";
+
+/** Free プランの通知オフセット（分） */
+export const OFFSETS_FREE: number[] = [1440]; // 24h
+
+/** Pro プランの通知オフセット（分） */
+export const OFFSETS_PRO: number[] = [4320, 1440, 180]; // 72h / 24h / 3h
+
+/** Cron ウィンドウ幅（分）: この範囲内の scheduled_for を持つレコードを対象とする */
+export const CRON_WINDOW_MINUTES = 10;
+
+/** 通知送信の結果サマリー */
+export interface NotifyResult {
+  processed: number; // 処理した (item, offset) ペア数
+  sent: number;
+  failed: number;
+  skipped: number; // 既に sent/failed だったためスキップ
+}
+
+/** scheduled_for からオフセットのラベルを返す（メール件名用） */
+export function offsetLabel(offsetMinutes: number): string {
+  if (offsetMinutes === 4320) return "72時間";
+  if (offsetMinutes === 1440) return "24時間";
+  if (offsetMinutes === 180) return "3時間";
+  return `${offsetMinutes}分`;
+}
+
+/**
+ * 通知メールの HTML を生成する。
+ * 将来的にテンプレートファイルへ移行できるよう関数として分離する。
+ */
+export function buildNotificationHtml(params: {
+  companyName: string;
+  kind: string;
+  deadlineAt: Date;
+  offsetMinutes: number;
+  appUrl: string;
+}): { subject: string; html: string; text: string } {
+  const { companyName, kind, deadlineAt, offsetMinutes, appUrl } = params;
+  const label = offsetLabel(offsetMinutes);
+
+  // JST 変換（JSTはUTC+9）
+  const deadlineJst = new Date(deadlineAt.getTime() + 9 * 60 * 60 * 1000);
+  const deadlineStr = deadlineJst
+    .toISOString()
+    .replace("T", " ")
+    .replace(/\..*$/, "")
+    .slice(0, 16); // "YYYY-MM-DD HH:MM"
+
+  const kindLabels: Record<string, string> = {
+    es: "ES",
+    briefing: "説明会",
+    interview: "面接",
+    other: "その他",
+  };
+  const kindLabel = kindLabels[kind] ?? kind;
+
+  const subject = `【締切${label}前】${companyName}（${kindLabel}）`;
+  const html = `
+<p>締切まで<strong>${label}</strong>です。</p>
+<p><strong>${companyName}</strong>（${kindLabel}）の締切は <strong>${deadlineStr} JST</strong> です。</p>
+<p><a href="${appUrl}/dashboard">ダッシュボードで確認する →</a></p>
+<hr>
+<p style="font-size:12px;color:#888;">
+  通知設定の変更は <a href="${appUrl}/billing">こちら</a>。
+  このメールは就活締切トラッカーから自動送信されています。
+</p>
+`.trim();
+  const text = `締切まで${label}です。\n${companyName}（${kindLabel}）の締切: ${deadlineStr} JST\n\nダッシュボード: ${appUrl}/dashboard`;
+
+  return { subject, html, text };
+}
+
+/**
+ * 通知 Cron のメイン処理。
+ *
+ * 1. 現在ウィンドウ内で通知すべき (DeadlineItem, offsetMinutes) ペアを収集する
+ * 2. 各ペアの notification_delivery を upsert（重複防止）
+ * 3. status=scheduled のレコードにメール送信
+ * 4. 成否で status を sent/failed に更新する
+ */
+export async function findAndDeliverNotifications(): Promise<NotifyResult> {
+  const now = new Date();
+  const windowMs = CRON_WINDOW_MINUTES * 60 * 1000;
+  const maxOffsetMs = Math.max(...OFFSETS_PRO) * 60 * 1000;
+  const appUrl = process.env.APP_URL ?? "http://localhost:3000";
+
+  // ウィンドウ内に scheduled_for (= deadline_at - offset) が入り得る
+  // deadline_at の範囲: now - WINDOW + minOffset <= deadline_at <= now + WINDOW + maxOffset
+  // シンプルに: deadline_at が now-WINDOW ~ now+maxOffset+WINDOW の間にある全 active アイテムを取得
+  const deadlineFrom = new Date(now.getTime() - windowMs);
+  const deadlineTo = new Date(now.getTime() + maxOffsetMs + windowMs);
+
+  const items = await prisma.deadlineItem.findMany({
+    where: {
+      deadlineAt: { gte: deadlineFrom, lte: deadlineTo },
+      // done/canceled は通知不要
+      status: { notIn: ["done", "canceled"] },
+    },
+    include: {
+      user: true,
+    },
+  });
+
+  const result: NotifyResult = {
+    processed: 0,
+    sent: 0,
+    failed: 0,
+    skipped: 0,
+  };
+
+  for (const item of items) {
+    // ユーザーのプランに応じてオフセットを決定
+    const isPro = await isProUser(item.userId);
+    const offsets = isPro ? OFFSETS_PRO : OFFSETS_FREE;
+
+    for (const offsetMinutes of offsets) {
+      // scheduled_for = deadline_at - offset_minutes
+      const scheduledFor = new Date(
+        item.deadlineAt.getTime() - offsetMinutes * 60 * 1000,
+      );
+
+      // このオフセットが現在ウィンドウ内に入るか確認
+      const windowStart = new Date(now.getTime() - windowMs);
+      const windowEnd = new Date(now.getTime() + windowMs);
+      if (scheduledFor < windowStart || scheduledFor > windowEnd) {
+        continue; // ウィンドウ外はスキップ
+      }
+
+      result.processed++;
+
+      // notification_delivery を upsert（一意制約: deadline_item_id + offset_minutes）
+      // update: {} にして既存レコードは変更しない（重複防止）
+      const delivery = await prisma.notificationDelivery.upsert({
+        where: {
+          uq_notification_deliveries_item_offset: {
+            deadlineItemId: item.id,
+            offsetMinutes,
+          },
+        },
+        create: {
+          deadlineItemId: item.id,
+          offsetMinutes,
+          scheduledFor,
+          status: "scheduled",
+        },
+        update: {}, // 既存があればそのまま（重複防止）
+      });
+
+      // status=scheduled のもののみ送信（sent/failed はスキップ）
+      if (delivery.status !== "scheduled") {
+        result.skipped++;
+        continue;
+      }
+
+      // メール送信
+      const { subject, html, text } = buildNotificationHtml({
+        companyName: item.companyName,
+        kind: item.kind,
+        deadlineAt: item.deadlineAt,
+        offsetMinutes,
+        appUrl,
+      });
+
+      const sendResult = await sendEmail({
+        to: item.user.email,
+        subject,
+        html,
+        text,
+      });
+
+      if (sendResult.ok) {
+        await prisma.notificationDelivery.update({
+          where: { id: delivery.id },
+          data: {
+            status: "sent",
+            sentAt: now,
+            providerMessageId: sendResult.messageId ?? null,
+          },
+        });
+        result.sent++;
+        console.log("[notify] sent", {
+          deadlineItemId: item.id,
+          offsetMinutes,
+          to: item.user.email,
+        });
+      } else {
+        await prisma.notificationDelivery.update({
+          where: { id: delivery.id },
+          data: {
+            status: "failed",
+            error: sendResult.error,
+          },
+        });
+        result.failed++;
+        console.error("[notify] failed", {
+          deadlineItemId: item.id,
+          offsetMinutes,
+          error: sendResult.error,
+        });
+      }
+    }
+  }
+
+  return result;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/notify",
+      "schedule": "*/10 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

Issue #15 対応。メール通知 Cron エンドポイント `POST /api/cron/notify` を実装した。  
Free=24h前、Pro=72h/24h/3h前のタイミングで締切メールを送信する。  
`notification_deliveries` の一意制約を使った冪等設計で重複送信を防止する。

## 変更理由

PRD Must-4「メール通知（Free=24h前, Pro=72h/24h/3h）」の実装に必要。  
ADR 0005 の信頼性設計（Cron + DBログ + 一意制約 + 冪等）に準拠する。

## 影響範囲

- [x] API（`POST /api/cron/notify` 新規追加）
- [ ] UI
- [ ] DB（スキーマ変更なし。`notification_deliveries` の既存制約を利用）
- [x] 設定/インフラ（`vercel.json` 追加、`.env.example` に `CRON_SECRET` 追加）
- [ ] 依存関係

## 変更ファイル一覧

| ファイル | 変更種別 | 概要 |
|---|---|---|
| `src/lib/notifications/notify.ts` | 新規 | 通知コアロジック（対象抽出・upsert・送信・DB更新） |
| `src/app/api/cron/notify/route.ts` | 新規 | Cron エンドポイント（CRON_SECRET Bearer 認証） |
| `src/lib/notifications/__tests__/notify.test.ts` | 新規 | 純粋関数ユニットテスト（11件）|
| `vercel.json` | 新規 | Vercel Cron 設定（10分間隔） |
| `.env.example` | 修正 | `CRON_SECRET` を追記 |
| `CHANGELOG.md` | 修正 | Unreleased に1行追記 |

## 設計ポイント

**ウィンドウ設計（ADR 0005）**
- `scheduled_for = deadline_at - offset_minutes`
- Cron 実行時に `now - 10min <= scheduled_for <= now + 10min` の範囲を抽出
- 10分のウィンドウで Cron の遅延・再実行によるとりこぼしをリカバリ

**冪等設計**
- `notification_deliveries.upsert(where: {deadline_item_id, offset_minutes}, update: {})` で重複作成を防止
- `status = scheduled` のレコードのみ送信し、`sent/failed` に更新済みはスキップ

**プラン分岐**
- `isProUser()` で判定し、Free=[1440min]、Pro=[4320, 1440, 180min] のオフセットを適用

## 確認手順

1. `.env` に `CRON_SECRET=test-secret` を追加する
2. ローカルサーバーを起動する（`npm run dev`）
3. 締切が24時間前後のアイテムを作成（`deadline_at = 現在 + 24h + 5min` 程度）する
4. 以下で Cron を手動実行する:
   ```sh
   curl -X POST http://localhost:3000/api/cron/notify \
     -H "Authorization: Bearer test-secret"
5. レスポンスに { ok: true, result: { processed: 1, sent: 1, ... } } が返ること
6. notification_deliveries テーブルで status = sent に更新されていること
7. メールログ（console）に送信内容が出力されていること
8. 同じ curl を再実行 → skipped: 1 になり再送信されないこと（重複防止）
9. Bearer トークンを変更して実行 → 401 が返ること