### PR TITLE
fix: #15 isProUser N+1クエリを修正 — proCache で同一ユーザーへの重複DB問い合わせを防止

### DIFF
--- a/src/lib/notifications/notify.ts
+++ b/src/lib/notifications/notify.ts
@@ -128,9 +128,18 @@ export async function findAndDeliverNotifications(): Promise<NotifyResult> {
     skipped: 0,
   };
 
+  // isProUser のキャッシュ: 同一 userId への重複 DB クエリを防ぐ（N+1対策）
+  const proCache = new Map<string, boolean>();
+  async function isProUserCached(userId: string): Promise<boolean> {
+    if (proCache.has(userId)) return proCache.get(userId)!;
+    const result = await isProUser(userId);
+    proCache.set(userId, result);
+    return result;
+  }
+
   for (const item of items) {
     // ユーザーのプランに応じてオフセットを決定
-    const isPro = await isProUser(item.userId);
+    const isPro = await isProUserCached(item.userId);
     const offsets = isPro ? OFFSETS_PRO : OFFSETS_FREE;
 
     for (const offsetMinutes of offsets) {


### PR DESCRIPTION
## 概要

`feat/15-notification-cron` で実装した通知 Cron のコアロジック（`notify.ts`）に存在していた N+1 クエリを修正した。

## 変更理由

`findAndDeliverNotifications()` の内側で `isProUser(userId)` をアイテムのループごとに呼んでいたため、同一ユーザーのアイテムが複数ある場合に同じ userId で何度も DB クエリが走っていた。

```ts
// 修正前: アイテムが5件あり同一ユーザーなら DB が5回叩かれる
for (const item of items) {
  const isPro = await isProUser(item.userId); // ← 毎回 DB
}