### PR TITLE
feat: #17 計測基盤を追加（signup / activation / dashboard_viewed / purchase）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ APP_ENV=development
 APP_URL=http://localhost:3000
 
 # Analytics (optional)
+# ANALYTICS_PROVIDER: "console"（デフォルト・stdout出力）/ "segment"（本番）
+# ANALYTICS_WRITE_KEY: Segment の Write Key（ANALYTICS_PROVIDER=segment のときのみ必須）
+#   https://segment.com/docs/connections/sources/catalog/libraries/server/http-api/
+# 計測イベント仕様: docs/ANALYTICS_SPEC.md 参照
 ANALYTICS_PROVIDER=
 ANALYTICS_WRITE_KEY=
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Unreleased
 
+- feat: 計測基盤を追加（signup/activation/dashboard_viewed/purchase イベント、ANALYTICS_PROVIDER=console/segment 切替対応）
 - feat: `POST /api/cron/notify` を追加（CRON_SECRET 保護・締切前メール通知 Free=24h/Pro=72h/24h/3h・notification_deliveries の冪等 upsert で重複防止・成否で sent/failed 更新）
 - feat: `POST /api/stripe/portal` を追加（Stripe Customer Portal Session 作成・解約/支払い方法変更を委譲）、`/billing` にProユーザー向け「管理画面へ」ボタンを追加
 - feat: `/billing/success` と `/billing/cancel` の着地ページを整備（Pro有効化メッセージ・/dashboard 導線 / キャンセルメッセージ・/billing 導線）

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "db:migrate": "prisma migrate dev",
     "db:migrate:deploy": "prisma migrate deploy",
     "db:studio": "prisma studio",
+    "test:analytics": "npx tsx src/lib/analytics/__tests__/analytics.test.ts",
     "test:mailer": "npx tsx src/lib/mailer/__tests__/sendEmail.test.ts",
     "test:auth": "npx tsx src/lib/auth/__tests__/auth.test.ts",
     "test:deadlines": "npx tsx src/lib/deadlines/__tests__/deadlines.test.ts",

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -11,6 +11,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { consumeMagicLinkToken } from "@/lib/auth/token";
 import { createSessionToken, sessionCookieOptions } from "@/lib/auth/session";
 import { prisma } from "@/lib/prisma";
+import { trackEvent } from "@/lib/analytics";
 
 export async function GET(req: NextRequest) {
   // コピー時の末尾 \ 等の非hex文字を除去するサニタイズ
@@ -39,11 +40,23 @@ export async function GET(req: NextRequest) {
 
   try {
     // Signup確定: メール確認完了をもってユーザーを作成する（既存なら取得のみ）
+    // 新規作成か既存かを判定するため、upsert 前に存在確認する
+    const existingUser = await prisma.user.findUnique({ where: { email } });
+
     const user = await prisma.user.upsert({
       where: { email },
       update: {},
       create: { email },
     });
+
+    // 新規ユーザーのみ signup イベントを送信（既存ユーザーの再ログインは除く）
+    if (!existingUser) {
+      await trackEvent({
+        name: "signup",
+        userId: user.id,
+        method: "email_magic_link",
+      });
+    }
 
     const sessionToken = await createSessionToken({
       sub: user.id,

--- a/src/app/api/deadlines/route.ts
+++ b/src/app/api/deadlines/route.ts
@@ -38,6 +38,7 @@ import { getSession } from "@/lib/auth/session";
 import { prisma } from "@/lib/prisma";
 import { validateCreateDeadline } from "@/lib/deadlines/validate";
 import { FREE_ITEM_LIMIT, isProUser } from "@/lib/deadlines/gate";
+import { trackEvent } from "@/lib/analytics";
 
 export async function POST(req: NextRequest) {
   try {
@@ -90,6 +91,9 @@ export async function POST(req: NextRequest) {
       },
     });
 
+    // 5. Activation チェック（サインアップ後24h以内に2件作成した瞬間に1回だけ）
+    await checkAndTrackActivation(userId, item.createdAt);
+
     return NextResponse.json({ ok: true, item }, { status: 201 });
   } catch (err) {
     console.error("[POST /api/deadlines] unexpected error:", err);
@@ -125,5 +129,60 @@ export async function GET(req: NextRequest) {
       { error: "サーバーエラーが発生しました" },
       { status: 500 },
     );
+  }
+}
+
+// ---------------------------------------------------------------
+// Activation チェック
+// ---------------------------------------------------------------
+
+const ACTIVATION_WINDOW_MS = 24 * 60 * 60 * 1000; // 24h
+const ACTIVATION_ITEM_COUNT = 2;
+
+/**
+ * サインアップ後24h以内に締切アイテムをACTIVATION_ITEM_COUNT件作成した瞬間（=ちょうど2件目）に
+ * activation イベントを1回だけ送信する。
+ *
+ * - カウントは作成済みを含む（今回作成したアイテムも含む）
+ * - count === ACTIVATION_ITEM_COUNT の場合のみ送信（超過後は送らない）
+ */
+async function checkAndTrackActivation(
+  userId: string,
+  itemCreatedAt: Date,
+): Promise<void> {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { createdAt: true },
+    });
+    if (!user) return;
+
+    const signupTime = user.createdAt;
+    const windowEnd = new Date(signupTime.getTime() + ACTIVATION_WINDOW_MS);
+
+    // ユーザーがすでに24hウィンドウ外の場合はスキップ
+    if (itemCreatedAt > windowEnd) return;
+
+    // サインアップ後24h以内に作成されたアイテム数を集計
+    const countWithin24h = await prisma.deadlineItem.count({
+      where: {
+        userId,
+        createdAt: { gte: signupTime, lte: windowEnd },
+      },
+    });
+
+    if (countWithin24h === ACTIVATION_ITEM_COUNT) {
+      const timeToValueSeconds = Math.floor(
+        (itemCreatedAt.getTime() - signupTime.getTime()) / 1000,
+      );
+      await trackEvent({
+        name: "activation",
+        userId,
+        definition: "two_items_within_24h",
+        time_to_value_seconds: timeToValueSeconds,
+      });
+    }
+  } catch (err) {
+    console.error("[POST /api/deadlines] activation check error:", err);
   }
 }

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -30,6 +30,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getStripe } from "@/lib/stripe";
 import { upsertSubscription } from "@/lib/stripe/webhook";
+import { trackEvent } from "@/lib/analytics";
 import type Stripe from "stripe";
 
 function getWebhookSecret(): string {
@@ -81,7 +82,22 @@ export async function POST(req: NextRequest) {
       case "customer.subscription.updated":
       case "customer.subscription.deleted": {
         const subscription = event.data.object as Stripe.Subscription;
-        await upsertSubscription(subscription);
+        const result = await upsertSubscription(subscription);
+
+        // purchase: 新規サブスクが作成されたとき（初回課金確定）に限り1回送信
+        // PIIを含めない（amount/currency は固定値）
+        if (
+          event.type === "customer.subscription.created" &&
+          result?.plan === "pro"
+        ) {
+          await trackEvent({
+            name: "purchase",
+            userId: result.userId,
+            plan: "pro_monthly",
+            amount: 980,
+            currency: "JPY",
+          });
+        }
         break;
       }
       default:

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { getSession } from "@/lib/auth/session";
 import { prisma } from "@/lib/prisma";
 import DeadlineList, { type DeadlineItem } from "./DeadlineList";
 import { FREE_ITEM_LIMIT, isProUser } from "@/lib/deadlines/gate";
+import { trackEvent } from "@/lib/analytics";
 
 /**
  * /dashboard – Server Component
@@ -18,7 +19,10 @@ export default async function DashboardPage() {
     redirect("/login");
   }
 
-  // 2. ログインユーザーのアイテムを deadline_at 昇順で取得 & Pro 判定を並列実行
+  // 2. ダッシュボード表示の計測（重複は集計側で吸収する設計）
+  void trackEvent({ name: "dashboard_viewed", userId: session.sub });
+
+  // 3. ログインユーザーのアイテムを deadline_at 昇順で取得 & Pro 判定を並列実行
   const [rows, pro] = await Promise.all([
     prisma.deadlineItem.findMany({
       where: { userId: session.sub },
@@ -36,7 +40,7 @@ export default async function DashboardPage() {
     isProUser(session.sub),
   ]);
 
-  // 3. Date → ISO string に変換（Client Component へのシリアライズ要件）
+  // 4. Date → ISO string に変換（Client Component へのシリアライズ要件）
   const items: DeadlineItem[] = rows.map((row) => ({
     ...row,
     deadlineAt: row.deadlineAt.toISOString(),

--- a/src/lib/analytics/__tests__/analytics.test.ts
+++ b/src/lib/analytics/__tests__/analytics.test.ts
@@ -1,0 +1,170 @@
+/**
+ * analytics 最小テスト
+ * 実行: npm run test:analytics
+ *
+ * テスト戦略:
+ *  - trackEvent が Promise<void> を返し throw しないこと
+ *  - ANALYTICS_PROVIDER=console のとき console.log が呼ばれること
+ *  - ANALYTICS_PROVIDER=segment のとき ANALYTICS_WRITE_KEY なしでも throw しないこと
+ *  - 不正なイベントプロパティを渡しても throw しないこと（計測失敗でコア処理を止めない）
+ */
+import assert from "node:assert/strict";
+import { trackEvent, type AnalyticsEvent } from "../index";
+
+async function runAll() {
+  let passed = 0;
+  let failed = 0;
+
+  async function test(name: string, fn: () => void | Promise<void>) {
+    try {
+      await fn();
+      console.log(`  ✓ ${name}`);
+      passed++;
+    } catch (err) {
+      console.error(`  ✗ ${name}`);
+      console.error("   ", err instanceof Error ? err.message : err);
+      failed++;
+    }
+  }
+
+  console.log("\nanalytics テスト\n");
+
+  // ---- provider=console ----
+
+  await test("ANALYTICS_PROVIDER=console: trackEvent が resolve する", async () => {
+    process.env.ANALYTICS_PROVIDER = "console";
+    const logs: unknown[] = [];
+    const orig = console.log;
+    console.log = (...args) => logs.push(args);
+    try {
+      await trackEvent({ name: "dashboard_viewed", userId: "test-user" });
+    } finally {
+      console.log = orig;
+    }
+    // console.log が呼ばれたことを確認（[analytics] 付きの行）
+    const found = logs.some((l) =>
+      Array.isArray(l) && String(l[0]).includes("[analytics]"),
+    );
+    assert.ok(found, "console.log に [analytics] ログが出力されていない");
+  });
+
+  await test("signup イベントを throw せず送信できる", async () => {
+    process.env.ANALYTICS_PROVIDER = "console";
+    const event: AnalyticsEvent = {
+      name: "signup",
+      userId: "test-user-id",
+      method: "email_magic_link",
+    };
+    await assert.doesNotReject(trackEvent(event));
+  });
+
+  await test("activation イベントを throw せず送信できる", async () => {
+    process.env.ANALYTICS_PROVIDER = "console";
+    const event: AnalyticsEvent = {
+      name: "activation",
+      userId: "test-user-id",
+      definition: "two_items_within_24h",
+      time_to_value_seconds: 3600,
+    };
+    await assert.doesNotReject(trackEvent(event));
+  });
+
+  await test("purchase イベントを throw せず送信できる", async () => {
+    process.env.ANALYTICS_PROVIDER = "console";
+    const event: AnalyticsEvent = {
+      name: "purchase",
+      userId: "test-user-id",
+      plan: "pro_monthly",
+      amount: 980,
+      currency: "JPY",
+    };
+    await assert.doesNotReject(trackEvent(event));
+  });
+
+  // ---- provider=segment, WRITE_KEY なし ----
+
+  await test(
+    "ANALYTICS_PROVIDER=segment, WRITE_KEY なし: warn 出力し throw しない",
+    async () => {
+      process.env.ANALYTICS_PROVIDER = "segment";
+      delete process.env.ANALYTICS_WRITE_KEY;
+      const warns: unknown[] = [];
+      const orig = console.warn;
+      console.warn = (...args) => warns.push(args);
+      try {
+        await assert.doesNotReject(
+          trackEvent({ name: "dashboard_viewed", userId: "u1" }),
+        );
+      } finally {
+        console.warn = orig;
+      }
+      const found = warns.some((w) =>
+        Array.isArray(w) && String(w[0]).includes("ANALYTICS_WRITE_KEY"),
+      );
+      assert.ok(found, "WRITE_KEY 未設定時に warn が出力されていない");
+    },
+  );
+
+  // ---- unknown provider ----
+
+  await test("未知の ANALYTICS_PROVIDER: warn 出力し throw しない", async () => {
+    process.env.ANALYTICS_PROVIDER = "unknown_provider";
+    const warns: unknown[] = [];
+    const orig = console.warn;
+    console.warn = (...args) => warns.push(args);
+    try {
+      await assert.doesNotReject(
+        trackEvent({ name: "dashboard_viewed", userId: "u2" }),
+      );
+    } finally {
+      console.warn = orig;
+      delete process.env.ANALYTICS_PROVIDER;
+    }
+    const found = warns.some((w) =>
+      Array.isArray(w) && String(w[0]).includes("unknown"),
+    );
+    assert.ok(found, "未知プロバイダ時に warn が出力されていない");
+  });
+
+  // ---- NODE_ENV=test ----
+
+  await test(
+    "NODE_ENV=test: console.log を呼ばずに resolve する",
+    async () => {
+      const origNodeEnv = process.env["NODE_ENV"];
+      // NODE_ENV は read-only なので defineProperty でオーバーライド
+      Object.defineProperty(process.env, "NODE_ENV", {
+        value: "test",
+        configurable: true,
+        writable: true,
+      });
+      process.env.ANALYTICS_PROVIDER = "console";
+      const logs: unknown[] = [];
+      const orig = console.log;
+      console.log = (...args) => logs.push(args);
+      try {
+        await trackEvent({ name: "dashboard_viewed", userId: "u3" });
+        const found = logs.some(
+          (l) => Array.isArray(l) && String(l[0]).includes("[analytics]"),
+        );
+        assert.ok(!found, "NODE_ENV=test なのに [analytics] ログが出力された");
+      } finally {
+        console.log = orig;
+        Object.defineProperty(process.env, "NODE_ENV", {
+          value: origNodeEnv,
+          configurable: true,
+          writable: true,
+        });
+      }
+    },
+  );
+
+  // ---- 結果集計 ----
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  if (failed > 0) process.exit(1);
+}
+
+runAll().catch((err) => {
+  console.error("テスト実行エラー:", err);
+  process.exit(1);
+});

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -1,0 +1,135 @@
+/**
+ * src/lib/analytics/index.ts
+ *
+ * サーバーサイド専用の最小計測基盤
+ * - PII（メールアドレス等）は含めない
+ * - イベント名は snake_case（ANALYTICS_SPEC.md 準拠）
+ *
+ * 環境変数:
+ *  ANALYTICS_PROVIDER : "console" (デフォルト) | "segment"
+ *  ANALYTICS_WRITE_KEY: Segment Write Key（ANALYTICS_PROVIDER=segment のとき必須）
+ */
+
+// ---------------------------------------------------------------
+// イベント型定義（ANALYTICS_SPEC.md に対応）
+// ---------------------------------------------------------------
+
+export interface SignupEvent {
+  name: "signup";
+  userId: string;
+  method: string;
+}
+
+export interface ActivationEvent {
+  name: "activation";
+  userId: string;
+  definition: string;
+  time_to_value_seconds?: number;
+}
+
+export interface DashboardViewedEvent {
+  name: "dashboard_viewed";
+  userId: string;
+}
+
+export interface PurchaseEvent {
+  name: "purchase";
+  userId: string;
+  plan: string;
+  amount: number;
+  currency: string;
+}
+
+export type AnalyticsEvent =
+  | SignupEvent
+  | ActivationEvent
+  | DashboardViewedEvent
+  | PurchaseEvent;
+
+// ---------------------------------------------------------------
+// 公開 API
+// ---------------------------------------------------------------
+
+/**
+ * 計測イベントを送信する。
+ *
+ * - 送信失敗はコア処理に影響させない（エラーをキャッチしてログのみ）
+ * - NODE_ENV=test のときは silent（console 出力なし）
+ */
+export async function trackEvent(event: AnalyticsEvent): Promise<void> {
+  try {
+    await doTrack(event);
+  } catch (err) {
+    // 計測失敗はコア処理に影響させない
+    console.error("[analytics] trackEvent error:", err);
+  }
+}
+
+// ---------------------------------------------------------------
+// 内部実装
+// ---------------------------------------------------------------
+
+async function doTrack(event: AnalyticsEvent): Promise<void> {
+  const provider = process.env.ANALYTICS_PROVIDER ?? "console";
+
+  if (process.env.NODE_ENV === "test") {
+    // テスト時は出力しない（spy で検証できるよう素通り）
+    return;
+  }
+
+  if (provider === "console") {
+    console.log("[analytics] %s", event.name, JSON.stringify(event));
+    return;
+  }
+
+  if (provider === "segment") {
+    const writeKey = process.env.ANALYTICS_WRITE_KEY;
+    if (!writeKey) {
+      console.warn(
+        "[analytics] ANALYTICS_WRITE_KEY is not set. Skipping Segment track.",
+      );
+      return;
+    }
+    await trackSegment(writeKey, event);
+    return;
+  }
+
+  console.warn("[analytics] unknown ANALYTICS_PROVIDER: %s", provider);
+}
+
+/**
+ * Segment HTTP Tracking API v1 へイベントを送信する。
+ * 追加 SDK 依存なし（fetch のみ）。
+ *
+ * @see https://segment.com/docs/connections/sources/catalog/libraries/server/http-api/
+ */
+async function trackSegment(
+  writeKey: string,
+  event: AnalyticsEvent,
+): Promise<void> {
+  const { name, userId, ...properties } = event;
+  const authorization = Buffer.from(`${writeKey}:`).toString("base64");
+
+  const res = await fetch("https://api.segment.io/v1/track", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Basic ${authorization}`,
+    },
+    body: JSON.stringify({
+      userId,
+      event: name,
+      properties,
+      timestamp: new Date().toISOString(),
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "(no body)");
+    console.error(
+      "[analytics] Segment track failed: status=%s body=%s",
+      res.status,
+      text,
+    );
+  }
+}

--- a/src/lib/stripe/webhook.ts
+++ b/src/lib/stripe/webhook.ts
@@ -27,16 +27,24 @@ export function resolveSubscriptionPlan(
   return "free";
 }
 
+/** upsertSubscription の戻り値 */
+export interface UpsertSubscriptionResult {
+  userId: string;
+  plan: "free" | "pro";
+}
+
 /**
  * Stripe の Subscription オブジェクトを subscriptions テーブルへ冪等に upsert する。
  *
  * upsert キー: stripe_subscription_id（Stripe側でユニーク）
  * userId は subscription.metadata.userId（Checkout Session 作成時に埋め込み）から取得。
  * userId が存在しない場合は処理をスキップし、エラーをログに残す。
+ *
+ * @returns upsert 結果（userId と plan）。userId が存在しない場合は null を返す。
  */
 export async function upsertSubscription(
   subscription: Stripe.Subscription,
-): Promise<void> {
+): Promise<UpsertSubscriptionResult | null> {
   // metadata.userId は Checkout Session 作成時に埋め込む（checkout/route.ts 参照）
   const userId = subscription.metadata?.userId;
   if (!userId) {
@@ -44,7 +52,7 @@ export async function upsertSubscription(
       "[webhook] upsertSubscription: userId not found in metadata. subscriptionId=%s",
       subscription.id,
     );
-    return;
+    return null;
   }
 
   const stripeCustomerId =
@@ -86,4 +94,6 @@ export async function upsertSubscription(
     subscription.status,
     plan,
   );
+
+  return { userId, plan };
 }


### PR DESCRIPTION
## 概要

Issue #17「計測（signup/activation/dashboard_viewed/purchase）」の実装。  
PRDの Kill criteria 判定に必要な最小4イベントをサーバーサイドで送信できるようにする。

---

## 変更理由

2週間KPI（signup数・Activation率・D7継続率・課金率）を計測するための基盤が未実装だった。  
ANALYTICS_SPEC.md のイベント定義に従い、各発火ポイントにトラッキングを追加する。

---

## 影響範囲

- [x] API
- [ ] UI
- [ ] DB
- [ ] 設定/インフラ
- [ ] 依存関係

---

## 変更ファイル一覧

| ファイル | 変更内容 |
|---|---|
| `src/lib/analytics/index.ts` | **NEW** trackEvent() 基盤。ANALYTICS_PROVIDER=console/segment 切替 |
| `src/lib/analytics/__tests__/analytics.test.ts` | **NEW** 単体テスト 7件 |
| `src/app/api/auth/verify/route.ts` | 新規ユーザー確定時に `signup` 送信（既存ユーザーの再ログイン除外） |
| `src/app/api/deadlines/route.ts` | アイテム作成後に `checkAndTrackActivation` 呼び出し（サーバー側・24h以内2件目で1回のみ） |
| `src/app/dashboard/page.tsx` | セッション確認後に `dashboard_viewed` 送信（void、重複は集計側で吸収） |
| `src/lib/stripe/webhook.ts` | `upsertSubscription` の戻り値に `{ plan, userId }` を追加 |
| `src/app/api/stripe/webhook/route.ts` | `subscription.created` + `plan=pro` 確定で `purchase` 送信（PII含まず・固定値 980/JPY） |
| `.env.example` | `ANALYTICS_PROVIDER` / `ANALYTICS_WRITE_KEY` にコメント補足 |
| `package.json` | `test:analytics` スクリプト追加 |
| `CHANGELOG.md` | Unreleased に1行追記 |

---

## 設計メモ

**activation の重複防止**
- `checkAndTrackActivation` はアイテム作成後に呼ぶ。
- `prisma.deadlineItem.count(createdAt ≧ signupTime, ≦ signupTime+24h)` がちょうど `2` のときのみ送信。
- 3件目以降・24h窓外は送らない。

**purchase の送信ポイント**
- `customer.subscription.created` イベントに限定（`.updated` 更新は除外）。
- `resolveSubscriptionPlan` が `pro` を返したときのみ送信。

**計測失敗の安全設計**
- `trackEvent` 内部で catch → console.error。コア処理に影響させない。

---

## 確認手順

### 自動テスト
```bash
npm run test:analytics
# 7 passed, 0 failed