### PR TITLE
fix: dashboard_viewed の void → await（Vercel での計測取りこぼし防止）

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -19,8 +19,8 @@ export default async function DashboardPage() {
     redirect("/login");
   }
 
-  // 2. ダッシュボード表示の計測（重複は集計側で吸収する設計）
-  void trackEvent({ name: "dashboard_viewed", userId: session.sub });
+  // 2. ダッシュボード表示の計測（重複は集計側で吸収する設計・エラーはキャッチ済みなのでawait可）
+  await trackEvent({ name: "dashboard_viewed", userId: session.sub });
 
   // 3. ログインユーザーのアイテムを deadline_at 昇順で取得 & Pro 判定を並列実行
   const [rows, pro] = await Promise.all([


### PR DESCRIPTION
## 概要

`dashboard_viewed` イベントの送信を `void`（fire and forget）から `await` に変更する。

## 変更理由

Vercel の Serverless 環境では、レスポンスを返した直後にプロセスが終了する場合がある。
`void trackEvent(...)` のままだと Promise が解決される前に終了し、**計測イベントが消える**ことがある。

`trackEvent` は内部で全エラーをキャッチしているため、`await` にしてもページ表示への影響はない。

## 影響範囲

- [x] API
- [ ] UI
- [ ] DB
- [ ] 設定/インフラ
- [ ] 依存関係

## 変更点

**`src/app/dashboard/page.tsx`**

```diff
- void trackEvent({ name: "dashboard_viewed", userId: session.sub });
+ await trackEvent({ name: "dashboard_viewed", userId: session.sub });