### PR TITLE
fix: Resend SDK v6 型エラーを修正（html/text の undefined 除外）

### DIFF
--- a/src/lib/mailer/providers/resend.ts
+++ b/src/lib/mailer/providers/resend.ts
@@ -18,13 +18,20 @@ export async function sendViaResend(
 
   const client = new Resend(apiKey);
 
-  const { data, error } = await client.emails.send({
+  // Resend v6 の型はユニオン（react 必須 or html/text オプション）のため、
+  // undefined を含むプロパティを渡すと型エラーになる。
+  // 定義済みのプロパティだけスプレッドで組み立ててキャストする。
+  const sendData = {
     from,
     to: Array.isArray(payload.to) ? payload.to : [payload.to],
     subject: payload.subject,
-    html: payload.html,
-    text: payload.text,
-  });
+    ...(payload.html !== undefined ? { html: payload.html } : {}),
+    ...(payload.text !== undefined ? { text: payload.text } : {}),
+  };
+
+  const { data, error } = await client.emails.send(
+    sendData as Parameters<typeof client.emails.send>[0],
+  );
 
   if (error) {
     return { ok: false, error: error.message ?? "Resend API エラー" };


### PR DESCRIPTION
## 変更概要

Resend SDK v6 の型変更に起因する TypeScript コンパイルエラーを修正。

## 背景

Resend v6 の `emails.send()` はユニオン型になり、`html`/`text` が `string | undefined` のまま渡すと型エラーになっていた。
本番ビルド（`next build`）が通らない状態だった。

## 変更ファイル

- `src/lib/mailer/providers/resend.ts`

## 変更内容

`html`/`text` が `undefined` のプロパティをスプレッドで除外してから送信オブジェクトを構築し、
型キャストで Resend の期待する型に合わせる。

## テスト

- `npx tsc --noEmit` → エラーゼロに改善
- `npm run test:mailer` → 4 passed, 0 failed（変更なし）

## リスク・ロールバック

影響範囲はメール送信のみ。ロジック変更なし（`undefined` プロパティを除くだけ）。
問題があれば `git revert` で即時戻し可能。