### PR TITLE
fix: analytics テストの NODE_ENV 上書きを直接代入に修正（7 passed → 0 failed）

### DIFF
--- a/src/lib/analytics/__tests__/analytics.test.ts
+++ b/src/lib/analytics/__tests__/analytics.test.ts
@@ -131,13 +131,12 @@ async function runAll() {
   await test(
     "NODE_ENV=test: console.log を呼ばずに resolve する",
     async () => {
-      const origNodeEnv = process.env["NODE_ENV"];
-      // NODE_ENV は read-only なので defineProperty でオーバーライド
-      Object.defineProperty(process.env, "NODE_ENV", {
-        value: "test",
-        configurable: true,
-        writable: true,
-      });
+      const env = process.env as Record<string, string | undefined>;
+      const origNodeEnv = env["NODE_ENV"];
+      // TypeScript の型定義では NODE_ENV は readonly だが、
+      // Node.js ランタイムでは process.env への直接代入が可能。
+      // Record<string, string | undefined> にキャストして上書きする。
+      env["NODE_ENV"] = "test";
       process.env.ANALYTICS_PROVIDER = "console";
       const logs: unknown[] = [];
       const orig = console.log;
@@ -150,11 +149,7 @@ async function runAll() {
         assert.ok(!found, "NODE_ENV=test なのに [analytics] ログが出力された");
       } finally {
         console.log = orig;
-        Object.defineProperty(process.env, "NODE_ENV", {
-          value: origNodeEnv,
-          configurable: true,
-          writable: true,
-        });
+        env["NODE_ENV"] = origNodeEnv;
       }
     },
   );


### PR DESCRIPTION
## 変更概要

`src/lib/analytics/__tests__/analytics.test.ts` の
`NODE_ENV=test` テストが `Object.defineProperty` の制約で失敗していた問題を修正。

## 背景

`test:analytics` 実行時に以下のエラーが発生していた。
✗ NODE_ENV=test: console.log を呼ばずに resolve する
'process.env' only accepts a configurable, writable, and enumerable data descriptor


`Object.defineProperty(process.env, "NODE_ENV", ...)` は tsx / Node.js の実行環境では
`NODE_ENV` が設定済み・non-configurable のため失敗する。

## 変更内容

`Object.defineProperty` による上書きを、`process.env` をインデックスシグネチャ型経由の
直接代入（`process.env["NODE_ENV"] = "test"`）に変更。

## テスト

```bash
npm run test:analytics
# 7 passed, 0 failed（修正前: 6 passed, 1 failed）

変更ファイル
src/lib/analytics/__tests__/analytics.test.ts

リスク
テストコードのみ変更。実装コードへの影響なし。