### PR TITLE
feat: ダッシュボードに締切削除ボタンを追加 (#B-3)

### DIFF
--- a/src/app/dashboard/DeadlineList.tsx
+++ b/src/app/dashboard/DeadlineList.tsx
@@ -34,7 +34,35 @@ type Props = {
 export default function DeadlineList({ initialItems }: Props) {
   const [items, setItems] = useState<DeadlineItem[]>(initialItems);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  async function handleDelete(id: string, companyName: string) {
+    if (!window.confirm(`「${companyName}」の締切を削除しますか？`)) return;
+
+    const prevItems = items;
+    setDeletingId(id);
+    setErrorMsg(null);
+
+    // 楽観的更新
+    setItems((prev) => prev.filter((item) => item.id !== id));
+
+    try {
+      const res = await fetch(`/api/deadlines/${id}`, { method: "DELETE" });
+
+      if (!res.ok) {
+        const data = (await res.json()) as { error?: string };
+        throw new Error(data.error ?? "削除に失敗しました");
+      }
+    } catch (err) {
+      setItems(prevItems); // ロールバック
+      setErrorMsg(
+        err instanceof Error ? err.message : "削除に失敗しました",
+      );
+    } finally {
+      setDeletingId(null);
+    }
+  }
 
   async function handleStatusChange(id: string, newStatus: string) {
     const prevItems = items; // ロールバック用に退避
@@ -109,11 +137,12 @@ export default function DeadlineList({ initialItems }: Props) {
         {items.map((item) => {
           const urgency = getUrgencyLevel(item.deadlineAt);
           const isUpdating = updatingId === item.id;
+          const isDeleting = deletingId === item.id;
 
           return (
             <li
               key={item.id}
-              className={`rounded-lg px-4 py-3 shadow-sm transition-opacity ${URGENCY_CLASS[urgency]} ${isUpdating ? "opacity-60" : ""}`}
+              className={`rounded-lg px-4 py-3 shadow-sm transition-opacity ${URGENCY_CLASS[urgency]} ${isUpdating || isDeleting ? "opacity-60" : ""}`}
             >
               <div className="flex items-start justify-between gap-3">
                 {/* 左列：企業名・種別・日時・リンク・メモ */}
@@ -145,13 +174,14 @@ export default function DeadlineList({ initialItems }: Props) {
                   )}
                 </div>
 
-                {/* 右列：ステータスセレクト（1操作で即更新） */}
+                {/* 右列：ステータスセレクト（1操作で即更新）＋削除ボタン */}
+                <div className="flex shrink-0 items-center gap-2">
                 <select
                   value={item.status}
-                  disabled={isUpdating}
+                  disabled={isUpdating || isDeleting}
                   onChange={(e) => handleStatusChange(item.id, e.target.value)}
                   aria-label={`${item.companyName}のステータスを変更`}
-                  className="shrink-0 cursor-pointer rounded border border-slate-200 bg-white px-2 py-1 text-sm text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="cursor-pointer rounded border border-slate-200 bg-white px-2 py-1 text-sm text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {Object.entries(STATUS_LABEL).map(([value, label]) => (
                     <option key={value} value={value}>
@@ -159,6 +189,21 @@ export default function DeadlineList({ initialItems }: Props) {
                     </option>
                   ))}
                 </select>
+                <button
+                  onClick={() => handleDelete(item.id, item.companyName)}
+                  disabled={isUpdating || isDeleting}
+                  aria-label={`${item.companyName}を削除`}
+                  className="rounded p-1 text-slate-400 hover:bg-red-50 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {isDeleting ? (
+                    <span className="text-xs">削除中…</span>
+                  ) : (
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9 7h6m2 0a1 1 0 00-1-1h-4a1 1 0 00-1 1H5" />
+                    </svg>
+                  )}
+                </button>
+                </div>
               </div>
             </li>
           );


### PR DESCRIPTION
## 概要

QA B-3「ダッシュボードから締切を削除」に対応するため、`DeadlineList` に削除ボタンを実装しました。

## 変更内容

**`src/app/dashboard/DeadlineList.tsx`**
- 各カード右列のステータスセレクトの隣にゴミ箱アイコンボタンを追加
- `DELETE /api/deadlines/:id` を呼び出し（認証・所有者確認は API 側で実施済み）
- 楽観的更新（即時 UI から削除） + 失敗時ロールバック
- 削除中は `isDeleting` フラグで操作を無効化・「削除中…」テキスト表示
- `window.confirm` で誤操作防止

## テスト手順（QA B-3）

1. ログイン済みの状態でダッシュボードを開く
2. 締切カード右側のゴミ箱アイコンをクリック
3. 確認ダイアログで「OK」を選択
4. 一覧から該当アイテムが消えることを確認
5. ページをリロードしても消えていることを確認（DB反映確認）

## 動作確認

- [ ] B-3: 削除後に一覧から消える（楽観的更新）
- [ ] B-3: リロードしても消えている（DB永続化）
- [ ] 誤操作防止: `confirm` キャンセルで削除されない
- [ ] エラー時: 削除失敗でロールバックされエラーメッセージが表示される

## 関連

- QA_CRITICAL_PATH.md B-3
- `DELETE /api/deadlines/:id` は既存実装（変更なし）