### PR TITLE
fix: Webhook upsert の一意制約エラーを修正（再契約時に 500 になるバグ）

### DIFF
--- a/src/lib/stripe/webhook.ts
+++ b/src/lib/stripe/webhook.ts
@@ -69,8 +69,11 @@ export async function upsertSubscription(
 
   const plan = resolveSubscriptionPlan(subscription.status, currentPeriodEnd);
 
+  // upsert キーを userId (@unique) にする。
+  // stripeSubscriptionId をキーにすると、再契約時（旧サブスク解約 → 新サブスク作成）に
+  // 新しい ID で CREATE しようとして user_id の UNIQUE 制約違反になるため。
   await prisma.subscription.upsert({
-    where: { stripeSubscriptionId: subscription.id },
+    where: { userId },
     create: {
       userId,
       stripeCustomerId,
@@ -81,6 +84,7 @@ export async function upsertSubscription(
     },
     update: {
       stripeCustomerId,
+      stripeSubscriptionId: subscription.id,
       status: subscription.status,
       plan,
       currentPeriodEnd,


### PR DESCRIPTION
## 概要

Pro 契約 → キャンセル（Cancel immediately）→ 再契約 の流れで
`POST /api/stripe/webhook` が 500 になるバグを修正。

## 原因

`upsertSubscription` の upsert キーが `stripeSubscriptionId` になっていた。
再契約時は Stripe が新しいサブスクリプション ID を発行するため、
`WHERE stripeSubscriptionId = 新ID` でレコードが見つからず CREATE しようとする。
しかし `user_id` には UNIQUE 制約があるため、既存レコードと衝突して
`Unique constraint failed on the fields: (user_id)` が発生し 500 になっていた。

## 修正内容

**`src/lib/stripe/webhook.ts`**

| 変更点 | 修正前 | 修正後 |
|--|--|--|
| upsert WHERE キー | `stripeSubscriptionId` | `userId`（@unique） |
| update フィールド | `stripeCustomerId, status, plan, currentPeriodEnd` | + `stripeSubscriptionId` を追加 |

upsert キーを `userId` にすることで「そのユーザーの最新サブスクリプション情報」を常に1レコードで管理する設計に統一。
再契約時も既存レコードが UPDATE されるため一意制約違反は発生しない。

## 再現手順

1. Stripe テストモードで Pro 契約（Checkout 完了）
2. Stripe ダッシュボードで「Cancel immediately」
3. 再度 `/billing` から Pro 契約
4. `stripe listen` ターミナルで `customer.subscription.created` が `[200]` になることを確認

## テスト

- [ ] `npm run test:webhook` が 0 failed（`resolveSubscriptionPlan` のユニットテスト）
- [ ] 上記の再現手順を実行して `[200]` が返ることを確認
- [ ] DB の `subscriptions` テーブルで `stripeSubscriptionId` が新しい ID に更新されていることを確認