### PR TITLE
fix: ESLint 設定を Next.js 15 × ESLint 9 互換の FlatCompat 形式に修正

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,28 @@
-// eslint-config-next exports a flat config array directly in Next.js 16
-import nextConfig from "eslint-config-next";
+// eslint-config-next@15 はレガシー形式（CommonJS + @rushstack/eslint-patch）のため、
+// ESLint 9 flat config から使う場合は @eslint/eslintrc の FlatCompat でラップする。
+// Next.js 16 以降になったら nextConfig を直接 spread するシンプルな形式に戻せる。
+// see: https://nextjs.org/docs/app/api-reference/config/eslint
+import { FlatCompat } from "@eslint/eslintrc";
+import path from "path";
+import { fileURLToPath } from "url";
 
-const config = [...nextConfig];
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const config = [
+  // ビルド成果物・依存パッケージは lint 対象外
+  {
+    ignores: [
+      ".next/**",
+      "node_modules/**",
+      "prisma/migrations/**",
+    ],
+  },
+  ...compat.extends("next/core-web-vitals"),
+];
+
 export default config;


### PR DESCRIPTION
## 概要

Next.js を 15.5.13 にダウングレードした際に生じた ESLint の起動エラーを修正する。

## 背景・原因

`eslint-config-next@15` は内部で `@rushstack/eslint-patch` を使うレガシー CommonJS 形式のため、
ESLint 9 の flat config（`eslint.config.mjs`）から直接 `import` すると以下のエラーが発生していた。

Error: Failed to patch ESLint because the calling module was not recognized.


元の `eslint.config.mjs` は Next.js 16 向けに書かれており、`eslint-config-next` が flat config を
ネイティブにエクスポートすることを前提としていた。

## 変更内容

**`eslint.config.mjs` のみ変更（1 ファイル）**

| 変更前 | 変更後 |
|--------|--------|
| `import nextConfig from "eslint-config-next"` で直接 spread | `@eslint/eslintrc` の `FlatCompat` でラップ |
| `.next/` 等の ignores なし | `ignores` に `.next/**` / `node_modules/**` / `prisma/migrations/**` を追加 |

## 検証結果
$ npm run lint
→ エラー 0 件 ✅

## 今後の対応

Next.js 16 以上に再アップグレードした際は、以下の 1 行形式に戻すだけでよい。

```js
import nextConfig from "eslint-config-next";
const config = [...nextConfig];
export default config;

## テスト計画
npm run lint → 正常終了（エラー 0 件）
手動確認: src配下のファイルを lint 警告なしで保存できること