### PR TITLE
fix: Cloudflare Workers デプロイ対応（ビルドエラー修正・設定整備）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ pnpm-debug.log*
 .env
 .env.*
 !.env.example
+
+# Cloudflare / OpenNext build output
+.open-next
+
+# Cloudflare local dev secrets
+.dev.vars

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "test:portal": "npx tsx src/lib/stripe/__tests__/portal.test.ts",
     "test:smoke": "bash scripts/smoke-test.sh",
     "build:cloudflare": "opennextjs-cloudflare build",
-    "preview": "wrangler dev",
-    "deploy": "wrangler deploy"
+    "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
+    "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
+    "upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",
+    "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
   },
   "dependencies": {
     "@prisma/client": "^7.5.0",

--- a/src/app/api/auth/magic-link/route.ts
+++ b/src/app/api/auth/magic-link/route.ts
@@ -5,7 +5,6 @@
  * - 常に 200 を返す（メール存在有無を漏らさないため）
  * - バリデーション失敗時のみ 400 を返す
  */
-export const runtime = "edge";
 
 import { NextRequest, NextResponse } from "next/server";
 import { createMagicLinkToken } from "@/lib/auth/token";

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -7,7 +7,6 @@
  *   ここでユーザーが存在しない場合に upsert する =
  *   「メール確認（マジックリンクのクリック）完了 = ユーザー作成確定」
  */
-export const runtime = "edge";
 
 import { NextRequest, NextResponse } from "next/server";
 import { consumeMagicLinkToken } from "@/lib/auth/token";

--- a/src/app/api/cron/notify/route.ts
+++ b/src/app/api/cron/notify/route.ts
@@ -25,7 +25,6 @@
  *  "crons": [{ "path": "/api/cron/notify", "schedule": "* /10 * * * *" }]
  *  ※ schedule: 10分間隔（"星印/10 * * * *"形式、JSDoc上の都合でスペース挿入済み）
  */
-export const runtime = "edge";
 
 import { NextRequest, NextResponse } from "next/server";
 import { findAndDeliverNotifications } from "@/lib/notifications/notify";

--- a/src/app/api/deadlines/[id]/route.ts
+++ b/src/app/api/deadlines/[id]/route.ts
@@ -25,7 +25,6 @@
  *  - セッションクッキーが必要（未ログインは 401）
  *  - 対象アイテムの所有者のみ削除可（他ユーザーは 403）
  */
-export const runtime = "edge";
 
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";

--- a/src/app/api/deadlines/route.ts
+++ b/src/app/api/deadlines/route.ts
@@ -33,7 +33,6 @@
  *  - Pro ユーザー（subscriptions.plan = "pro" かつ active/trialing または current_period_end が未来）は無制限
  *  - それ以外（Free）は 10 件まで。超過時は 403 を返す
  */
-export const runtime = "edge";
 
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -17,7 +17,6 @@
  *  - { ok: true, url: string }  200  Stripe Checkout URL
  *  - { error: string }          401 / 405 / 500
  */
-export const runtime = "edge";
 
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";

--- a/src/app/api/stripe/portal/route.ts
+++ b/src/app/api/stripe/portal/route.ts
@@ -24,7 +24,6 @@
  *  - { error: string }          405  GET不可
  *  - { error: string }          500  サーバーエラー
  */
-export const runtime = "edge";
 
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -27,7 +27,6 @@
  *  - { error: string }    400  署名検証失敗
  *  - { error: string }    500  サーバーエラー
  */
-export const runtime = "edge";
 
 import { NextRequest, NextResponse } from "next/server";
 import { getStripe } from "@/lib/stripe";

--- a/src/lib/auth/token.ts
+++ b/src/lib/auth/token.ts
@@ -6,7 +6,7 @@
  * - 使い捨て: 一度使われたトークンは再利用不可
  * - 同一メールの期限切れトークンは作成時にクリーンアップ
  */
-import { randomBytes } from "crypto";
+import { randomBytes } from "node:crypto";
 import { prisma } from "@/lib/prisma";
 
 const EXPIRY_MINUTES = parseInt(

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,15 +1,38 @@
 # Cloudflare Workers 設定
 # @opennextjs/cloudflare が生成した .open-next/worker.js を Deploy する
 # see: https://opennext.js.org/cloudflare
+#
+# ── デプロイ手順 ────────────────────────────────────────────────────
+#   1. npm run build:cloudflare   (opennextjs-cloudflare build)
+#   2. シークレット登録（初回のみ）:
+#        wrangler secret put DATABASE_URL
+#        wrangler secret put AUTH_SECRET
+#        wrangler secret put APP_URL
+#        wrangler secret put RESEND_API_KEY
+#        wrangler secret put EMAIL_FROM
+#        wrangler secret put STRIPE_SECRET_KEY
+#        wrangler secret put STRIPE_PRICE_ID
+#        wrangler secret put STRIPE_WEBHOOK_SECRET
+#        wrangler secret put CRON_SECRET
+#   3. npm run deploy              (wrangler deploy)
+# -------------------------------------------------------------------
 
 name = "job-hunt-deadline-tracker"
 main = ".open-next/worker.js"
-compatibility_date = "2024-09-23"
+compatibility_date = "2025-09-23"
 compatibility_flags = ["nodejs_compat"]
 
 [assets]
 directory = ".open-next/assets"
 binding = "ASSETS"
+
+# ── 公開可能な環境変数（非機密） ─────────────────────────────────────
+# 機密情報は [vars] に書かず wrangler secret put で登録すること
+[vars]
+APP_ENV = "production"
+EMAIL_PROVIDER = "resend"
+MAGIC_LINK_EXPIRY_MINUTES = "30"
+ANALYTICS_PROVIDER = "console"
 
 # Cron トリガー: 10分ごとに /api/cron/notify を呼び出す
 # 本番環境は Cloudflare Dashboard の Triggers タブでも管理可能


### PR DESCRIPTION
## 概要
Cloudflare Workers へのデプロイに必要な修正・設定変更をまとめて対応。
ビルドログで確認された `Module not found: Can't resolve 'crypto'` エラーを解消し、公式ドキュメント準拠の設定に更新。

## 変更内容

### バグ修正
- `src/lib/auth/token.ts`: `import { randomBytes } from "crypto"` → `from "node:crypto"` に変更（Cloudflare Workers は `node:` プレフィックス必須）

### `export const runtime = "edge"` 削除（全8ルート）
`@opennextjs/cloudflare` は Edge Runtime 未サポート。この宣言が原因で Cloudflare のビルドが Node.js の `crypto` モジュールを解決できずビルド失敗していた。
- `src/app/api/auth/magic-link/route.ts`
- `src/app/api/auth/verify/route.ts`
- `src/app/api/cron/notify/route.ts`
- `src/app/api/deadlines/route.ts`
- `src/app/api/deadlines/[id]/route.ts`
- `src/app/api/stripe/checkout/route.ts`
- `src/app/api/stripe/portal/route.ts`
- `src/app/api/stripe/webhook/route.ts`

### 設定ファイル
- `wrangler.toml`: `[vars]` に非機密の環境変数を追加、デプロイ手順コメントを追加
- `package.json`: `deploy` / `preview` スクリプトを公式推奨形式に更新、`upload` / `cf-typegen` を追加
- `.gitignore`: `.open-next`（ビルド成果物）と `.dev.vars`（ローカル秘密情報）を追加

## 確認項目
- [ ] Cloudflare Pages でビルドが通ること
- [ ] `/login` → メール送信 → `/dashboard` の導線が動作すること
- [ ] Stripe Webhook が受信できること