### PR TITLE
fix: ビルド時 PrismaClient 初期化エラーを修正（force-dynamic追加）

### DIFF
--- a/src/app/api/auth/magic-link/route.ts
+++ b/src/app/api/auth/magic-link/route.ts
@@ -6,6 +6,8 @@
  * - バリデーション失敗時のみ 400 を返す
  */
 
+export const dynamic = "force-dynamic";
+
 import { NextRequest, NextResponse } from "next/server";
 import { createMagicLinkToken } from "@/lib/auth/token";
 import { sendEmail } from "@/lib/mailer";

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -8,6 +8,8 @@
  *   「メール確認（マジックリンクのクリック）完了 = ユーザー作成確定」
  */
 
+export const dynamic = "force-dynamic";
+
 import { NextRequest, NextResponse } from "next/server";
 import { consumeMagicLinkToken } from "@/lib/auth/token";
 import { createSessionToken, sessionCookieOptions } from "@/lib/auth/session";

--- a/src/app/api/cron/notify/route.ts
+++ b/src/app/api/cron/notify/route.ts
@@ -26,6 +26,8 @@
  *  ※ schedule: 10分間隔（"星印/10 * * * *"形式、JSDoc上の都合でスペース挿入済み）
  */
 
+export const dynamic = "force-dynamic";
+
 import { NextRequest, NextResponse } from "next/server";
 import { findAndDeliverNotifications } from "@/lib/notifications/notify";
 

--- a/src/app/api/deadlines/[id]/route.ts
+++ b/src/app/api/deadlines/[id]/route.ts
@@ -26,6 +26,8 @@
  *  - 対象アイテムの所有者のみ削除可（他ユーザーは 403）
  */
 
+export const dynamic = "force-dynamic";
+
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { prisma } from "@/lib/prisma";

--- a/src/app/api/deadlines/route.ts
+++ b/src/app/api/deadlines/route.ts
@@ -34,6 +34,8 @@
  *  - それ以外（Free）は 10 件まで。超過時は 403 を返す
  */
 
+export const dynamic = "force-dynamic";
+
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { prisma } from "@/lib/prisma";

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -18,6 +18,8 @@
  *  - { error: string }          401 / 405 / 500
  */
 
+export const dynamic = "force-dynamic";
+
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { getStripe } from "@/lib/stripe";

--- a/src/app/api/stripe/portal/route.ts
+++ b/src/app/api/stripe/portal/route.ts
@@ -25,6 +25,8 @@
  *  - { error: string }          500  サーバーエラー
  */
 
+export const dynamic = "force-dynamic";
+
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { getStripe } from "@/lib/stripe";

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -28,6 +28,8 @@
  *  - { error: string }    500  サーバーエラー
  */
 
+export const dynamic = "force-dynamic";
+
 import { NextRequest, NextResponse } from "next/server";
 import { getStripe } from "@/lib/stripe";
 import { upsertSubscription } from "@/lib/stripe/webhook";


### PR DESCRIPTION
## 概要
前回の `export const runtime = "edge"` 削除後に発生した新規ビルドエラーを修正。

## 原因
`export const runtime = "edge"` には「ビルド時の静的解析をスキップする」副作用があった。
削除後、Next.js がビルド時に各 API route を静的解析しようとし、
モジュールレベルで `PrismaClient` が初期化 → `DATABASE_URL` 未設定でクラッシュ。


## 修正内容
全8 API route に `export const dynamic = "force-dynamic"` を追加し、ビルド時の静的生成を明示的に無効化。

- `src/app/api/auth/magic-link/route.ts`
- `src/app/api/auth/verify/route.ts`
- `src/app/api/cron/notify/route.ts`
- `src/app/api/deadlines/route.ts`
- `src/app/api/deadlines/[id]/route.ts`
- `src/app/api/stripe/checkout/route.ts`
- `src/app/api/stripe/portal/route.ts`
- `src/app/api/stripe/webhook/route.ts`

## 確認項目
- [ ] Cloudflare Pages でビルドが通ること
- [ ] `/login` → メール送信 → `/dashboard` の導線が動作すること