### PR TITLE
fix: PrismaClient をLazy Proxy化してビルド時の初期化エラーを根本解消

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -10,7 +10,7 @@ import { withAccelerate } from "@prisma/extension-accelerate";
 
 // globalThis を使用（global は Edge Runtime で非推奨）
 const globalForPrisma = globalThis as unknown as {
-  prisma: ReturnType<typeof createPrismaClient>;
+  prisma: ReturnType<typeof createPrismaClient> | undefined;
 };
 
 function createPrismaClient() {
@@ -19,8 +19,18 @@ function createPrismaClient() {
   return new PrismaClient().$extends(withAccelerate());
 }
 
-export const prisma = globalForPrisma.prisma ?? createPrismaClient();
-
-if (process.env.NODE_ENV !== "production") {
-  globalForPrisma.prisma = prisma;
+function getPrismaClient(): ReturnType<typeof createPrismaClient> {
+  if (!globalForPrisma.prisma) {
+    globalForPrisma.prisma = createPrismaClient();
+  }
+  return globalForPrisma.prisma;
 }
+
+// Lazy Proxy: モジュールインポート時に PrismaClient を初期化しない。
+// 初回プロパティアクセス時（実リクエスト時）に初期化することで、
+// Next.js ビルド時に DATABASE_URL が未設定でもクラッシュしない。
+export const prisma = new Proxy({} as ReturnType<typeof createPrismaClient>, {
+  get(_target, prop: string | symbol) {
+    return (getPrismaClient() as unknown as Record<string | symbol, unknown>)[prop];
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## 概要
Cloudflare Pages ビルド時に発生する `PrismaClientInitializationError` を根本修正。

## 原因
Next.js はビルド時に全モジュールを `import` して静的解析する。
その際 `prisma.ts` がモジュールレベルで `new PrismaClient()` を実行するが、
ビルド環境には `DATABASE_URL` が存在しないため初期化エラーが発生していた。


`force-dynamic` を追加しても Next.js はモジュールを import するため根本解決にはならなかった。

## 修正内容（`src/lib/prisma.ts`）

Proxy パターンを使って PrismaClient の初期化を遅延させる。

- **変更前**: モジュール import 時に `new PrismaClient()` を実行
- **変更後**: `Proxy` ラッパーで包み、初回プロパティアクセス時（実リクエスト時）に初期化

```ts
// 変更後のイメージ
export const prisma = new Proxy({} as ReturnType<typeof createPrismaClient>, {
  get(_target, prop) {
    return getPrismaClient()[prop]; // 初回アクセス時に初期化
  },
});