### PR TITLE
feat: 特定商取引法に基づく表記ページを追加 / フッターのリンク・メールを更新

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,8 +22,11 @@ export default function RootLayout({
             <Link href="/privacy" className="hover:underline">
               プライバシーポリシー
             </Link>
+            <Link href="/legal" className="hover:underline">
+              特定商取引法に基づく表記
+            </Link>
             <a
-              href="mailto:support@example.com"
+              href="mailto:haruya.0411.k@gmail.com"
               className="hover:underline"
             >
               お問い合わせ

--- a/src/app/legal/page.tsx
+++ b/src/app/legal/page.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "特定商取引法に基づく表記 | 〆トラ",
+};
+
+const ITEMS: { label: string; value: React.ReactNode }[] = [
+  { label: "販売業者", value: "川﨑　遥也" },
+  {
+    label: "所在地",
+    value: "請求があれば遅滞なく開示いたします",
+  },
+  {
+    label: "連絡先",
+    value: (
+      <a
+        href="mailto:haruya.0411.k@gmail.com"
+        className="text-blue-600 hover:underline"
+      >
+        haruya.0411.k@gmail.com
+      </a>
+    ),
+  },
+  {
+    label: "販売価格",
+    value: "Proプラン：980円（税込）/ 月",
+  },
+  {
+    label: "支払方法",
+    value: "クレジットカード（Visa・Mastercard・American Express・JCB 等）",
+  },
+  {
+    label: "支払時期",
+    value:
+      "お申し込み完了時に初回課金が発生し、以降は毎月同日に自動更新されます。",
+  },
+  {
+    label: "サービス提供時期",
+    value: "決済完了後、即時にご利用いただけます。",
+  },
+  {
+    label: "返品・キャンセルについて",
+    value:
+      "デジタルコンテンツの性質上、原則として返金はお受けできません。サブスクリプションはいつでもキャンセル可能です。キャンセル後は現在の契約期間終了までサービスをご利用いただけます。",
+  },
+  {
+    label: "動作環境",
+    value:
+      "最新バージョンの Google Chrome・Safari・Firefox・Edge を推奨します。",
+  },
+];
+
+export default function LegalPage() {
+  const updatedAt = "2026年3月19日";
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-12 text-sm leading-relaxed text-slate-700">
+      <h1 className="mb-2 text-2xl font-bold text-slate-900">
+        特定商取引法に基づく表記
+      </h1>
+      <p className="mb-8 text-xs text-slate-500">最終更新: {updatedAt}</p>
+
+      <table className="w-full border-collapse text-sm">
+        <tbody>
+          {ITEMS.map(({ label, value }) => (
+            <tr key={label} className="border-t border-slate-200">
+              <th className="w-36 py-4 pr-4 text-left align-top font-semibold text-slate-900">
+                {label}
+              </th>
+              <td className="py-4 text-slate-700">{value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="mt-10 text-xs text-slate-400">
+        <Link href="/" className="hover:underline">
+          ← トップへ戻る
+        </Link>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## 概要

Stripe から「特定商取引法に基づく表記ページが存在しない」として審査が否決されたため、対応ページを追加。

---

## 変更内容

### 新規: `src/app/legal/page.tsx`（`/legal`）

特定商取引法に基づく表記ページを新規作成。記載項目:

| 項目 | 内容 |
|---|---|
| 販売業者 | 川﨑　遥也 |
| 所在地 | 請求があれば遅滞なく開示 |
| 連絡先 | haruya.0411.k@gmail.com |
| 販売価格 | Proプラン 980円（税込）/月 |
| 支払方法 | クレジットカード（Stripe経由） |
| 支払時期 | 申込時に初回課金・以降毎月自動更新 |
| 提供時期 | 決済完了後即時 |
| 返品・キャンセル | デジタルコンテンツのため原則返金不可。キャンセル後は期間終了まで利用可 |

### 変更: `src/app/layout.tsx`

- フッターに「特定商取引法に基づく表記」リンク（`/legal`）を追加
- お問い合わせメールを `support@example.com`（仮）→ `haruya.0411.k@gmail.com` に変更

---

## テスト計画

- [ ] `https://shimetra.com/legal` にアクセスして表が正しく表示されること
- [ ] フッターから `/legal` へのリンクが機能すること
- [ ] お問い合わせリンクが正しいメールアドレスを開くこと

---

## 背景

Stripe 審査メールの要件:
> ウェブサイト内に Stripe の基準を満たす「特定商取引法に基づく表記」ページが存在すること