### PR TITLE
[Refactor] kharuya.0411.k@gmail.comをsupport@shimetra.comに再変更

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
               特定商取引法に基づく表記
             </Link>
             <a
-              href="mailto:haruya.0411.k@gmail.com"
+              href="mailto:support@shimetra.com"
               className="hover:underline"
             >
               お問い合わせ

--- a/src/app/legal/page.tsx
+++ b/src/app/legal/page.tsx
@@ -15,10 +15,10 @@ const ITEMS: { label: string; value: React.ReactNode }[] = [
     label: "連絡先",
     value: (
       <a
-        href="mailto:haruya.0411.k@gmail.com"
+        href="mailto:support@shimetra.com"
         className="text-blue-600 hover:underline"
       >
-        haruya.0411.k@gmail.com
+        support@shimetra.com
       </a>
     ),
   },


### PR DESCRIPTION
## 対象

 現在、仮置きしているsupport@example.comが書かれている箇所

## 現状の問題

 実装時に仮置きしていたsupport@example.comが実際のメールアドレスに変更されていない箇所があった。

## 目的

kharuya.0411.k@gmail.comも同様にsupport@shimetra.comに置き換える

## 非目的
メールアドレス以外の部分を書き換える

## 実施内容

- [ ] kharuya.0411.k@gmail.comをsupport@shimetra.comに置き換える

## 受け入れ条件

- [ ] kharuya.0411.k@gmail.comがsupport@shimetra.comに置き換わっている

## リスク・注意点

メールアドレス箇所以外は書き換えない
