### PR TITLE
feat(lp): LPセクションを個別コンポーネントに分割

### DIFF
--- a/src/app/_components/lp/BenefitSection.tsx
+++ b/src/app/_components/lp/BenefitSection.tsx
@@ -1,0 +1,43 @@
+import { LP_CONTENT } from "./content";
+
+/**
+ * BenefitSection — 利用後の変化を具体化するセクション（ダーク背景）
+ */
+export function BenefitSection() {
+  const { benefit } = LP_CONTENT;
+
+  return (
+    <section className="py-20" style={{ backgroundColor: "#30302e" }}>
+      <div className="mx-auto max-w-5xl px-6">
+        <h2
+          className="text-center text-3xl font-medium"
+          style={{
+            color: "#faf9f5",
+            fontFamily: "Georgia, serif",
+            lineHeight: 1.2,
+          }}
+        >
+          {benefit.heading}
+        </h2>
+        <ul className="mx-auto mt-10 max-w-md space-y-5">
+          {benefit.items.map((item) => (
+            <li
+              key={item}
+              className="flex items-start gap-3 text-base leading-relaxed"
+              style={{ color: "#b0aea5" }}
+            >
+              <span
+                className="mt-0.5 flex-shrink-0"
+                style={{ color: "#c96442" }}
+                aria-hidden="true"
+              >
+                ✓
+              </span>
+              {item}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/app/_components/lp/BetaCtaSection.tsx
+++ b/src/app/_components/lp/BetaCtaSection.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { LP_CONTENT } from "./content";
+
+/**
+ * BetaCtaSection — 下部の登録導線セクション（ダーク背景）
+ * CTA: 先行利用に登録する
+ */
+export function BetaCtaSection() {
+  const { betaCta } = LP_CONTENT;
+
+  return (
+    <section
+      className="py-24 text-center"
+      style={{ backgroundColor: "#141413" }}
+    >
+      <div className="mx-auto max-w-5xl px-6">
+        <h2
+          className="text-3xl font-medium sm:text-4xl"
+          style={{
+            color: "#faf9f5",
+            fontFamily: "Georgia, serif",
+            lineHeight: 1.2,
+          }}
+        >
+          {betaCta.heading}
+        </h2>
+        <p
+          className="mx-auto mt-4 max-w-lg text-base leading-relaxed"
+          style={{ color: "#b0aea5" }}
+        >
+          {betaCta.body}
+        </p>
+        <div className="mt-10">
+          <Link
+            href="/login"
+            className="inline-block rounded-lg px-8 py-3.5 text-base font-medium transition-opacity hover:opacity-90"
+            style={{ backgroundColor: "#c96442", color: "#faf9f5" }}
+          >
+            {betaCta.ctaLabel}
+          </Link>
+        </div>
+        <p className="mt-4 text-sm" style={{ color: "#87867f" }}>
+          {betaCta.note}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/_components/lp/DifferenceSection.tsx
+++ b/src/app/_components/lp/DifferenceSection.tsx
@@ -1,0 +1,56 @@
+import { LP_CONTENT } from "./content";
+
+/**
+ * DifferenceSection — 既存手段との違いと価値ループを示すセクション
+ */
+export function DifferenceSection() {
+  const { difference } = LP_CONTENT;
+
+  return (
+    <section className="py-20" style={{ backgroundColor: "#f5f4ed" }}>
+      <div className="mx-auto max-w-5xl px-6 text-center">
+        <h2
+          className="text-3xl font-medium"
+          style={{
+            color: "#141413",
+            fontFamily: "Georgia, serif",
+            lineHeight: 1.2,
+          }}
+        >
+          {difference.heading}
+        </h2>
+        <p
+          className="mx-auto mt-4 max-w-lg text-base leading-relaxed"
+          style={{ color: "#5e5d59" }}
+        >
+          {difference.body}
+        </p>
+        {/* 価値ループ */}
+        <div
+          className="mt-10 flex flex-wrap items-center justify-center gap-2"
+          aria-label="価値ループ"
+        >
+          {difference.loop.map((step, i) => (
+            <div key={step} className="flex items-center gap-2">
+              <span
+                className="rounded-full px-4 py-1.5 text-sm font-medium"
+                style={{
+                  backgroundColor: "#faf9f5",
+                  border: "1px solid #e8e6dc",
+                  color: "#4d4c48",
+                }}
+              >
+                {step}
+              </span>
+              {i < difference.loop.length - 1 && (
+                <span style={{ color: "#c96442" }} aria-hidden="true">
+                  →
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/_components/lp/HeroSection.tsx
+++ b/src/app/_components/lp/HeroSection.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import { LP_CONTENT } from "./content";
+
+/**
+ * HeroSection — 誰向けの価値かを最初に伝えるセクション
+ * CTA: 先行利用に登録する
+ */
+export function HeroSection() {
+  const { hero } = LP_CONTENT;
+
+  return (
+    <section className="mx-auto max-w-5xl px-6 py-24 text-center">
+      <h1
+        className="mx-auto max-w-2xl text-4xl font-medium leading-tight sm:text-5xl"
+        style={{
+          color: "#141413",
+          fontFamily: "Georgia, serif",
+          lineHeight: 1.1,
+        }}
+      >
+        {hero.heading}
+      </h1>
+      <p
+        className="mx-auto mt-6 max-w-xl text-lg leading-relaxed"
+        style={{ color: "#5e5d59" }}
+      >
+        {hero.subCopy}
+      </p>
+      <div className="mt-10">
+        <Link
+          href="/login"
+          className="inline-block rounded-lg px-8 py-3.5 text-base font-medium transition-opacity hover:opacity-90"
+          style={{ backgroundColor: "#c96442", color: "#faf9f5" }}
+        >
+          {hero.ctaLabel}
+        </Link>
+      </div>
+      <p className="mt-4 text-sm" style={{ color: "#87867f" }}>
+        {hero.note}
+      </p>
+    </section>
+  );
+}

--- a/src/app/_components/lp/HowItWorksSection.tsx
+++ b/src/app/_components/lp/HowItWorksSection.tsx
@@ -1,0 +1,54 @@
+import { LP_CONTENT } from "./content";
+
+/**
+ * HowItWorksSection — 価値の流れを3ステップで示すセクション
+ */
+export function HowItWorksSection() {
+  const { howItWorks } = LP_CONTENT;
+
+  return (
+    <section className="py-20" style={{ backgroundColor: "#f5f4ed" }}>
+      <div className="mx-auto max-w-5xl px-6">
+        <h2
+          className="text-center text-3xl font-medium"
+          style={{
+            color: "#141413",
+            fontFamily: "Georgia, serif",
+            lineHeight: 1.2,
+          }}
+        >
+          {howItWorks.heading}
+        </h2>
+        <div className="mx-auto mt-12 grid max-w-3xl grid-cols-1 gap-6 sm:grid-cols-3">
+          {howItWorks.steps.map(({ number, label }) => (
+            <div
+              key={number}
+              className="rounded-2xl p-6"
+              style={{
+                backgroundColor: "#faf9f5",
+                border: "1px solid #f0eee6",
+              }}
+            >
+              <div
+                className="mb-4 text-3xl font-medium"
+                style={{
+                  color: "#c96442",
+                  fontFamily: "Georgia, serif",
+                }}
+                aria-label={`ステップ ${number}`}
+              >
+                {number}
+              </div>
+              <p
+                className="text-base leading-relaxed"
+                style={{ color: "#4d4c48" }}
+              >
+                {label}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/_components/lp/LandingPage.tsx
+++ b/src/app/_components/lp/LandingPage.tsx
@@ -1,13 +1,18 @@
 import Link from "next/link";
 import { LP_CONTENT } from "./content";
+import { HeroSection } from "./HeroSection";
+import { ProblemSection } from "./ProblemSection";
+import { HowItWorksSection } from "./HowItWorksSection";
+import { BenefitSection } from "./BenefitSection";
+import { DifferenceSection } from "./DifferenceSection";
+import { BetaCtaSection } from "./BetaCtaSection";
 
 /**
  * LP全体レイアウトを束ねる Server Component
  * デザイン方針: docs/DESIGN.md 参照（パーチメント系カラー + テラコッタCTA）
  */
 export function LandingPage() {
-  const { hero, problem, howItWorks, benefit, difference, betaCta } =
-    LP_CONTENT;
+  const { hero } = LP_CONTENT;
 
   return (
     // パーチメント背景 (#f5f4ed)
@@ -38,229 +43,12 @@ export function LandingPage() {
       </header>
 
       <main>
-        {/* HeroSection */}
-        <section className="mx-auto max-w-5xl px-6 py-24 text-center">
-          <h1
-            className="mx-auto max-w-2xl text-4xl font-medium leading-tight sm:text-5xl"
-            style={{
-              color: "#141413",
-              fontFamily: "Georgia, serif",
-              lineHeight: 1.1,
-            }}
-          >
-            {hero.heading}
-          </h1>
-          <p
-            className="mx-auto mt-6 max-w-xl text-lg leading-relaxed"
-            style={{ color: "#5e5d59" }}
-          >
-            {hero.subCopy}
-          </p>
-          <div className="mt-10">
-            <Link
-              href="/login"
-              className="inline-block rounded-lg px-8 py-3.5 text-base font-medium transition-opacity hover:opacity-90"
-              style={{ backgroundColor: "#c96442", color: "#faf9f5" }}
-            >
-              {hero.ctaLabel}
-            </Link>
-          </div>
-          <p className="mt-4 text-sm" style={{ color: "#87867f" }}>
-            {hero.note}
-          </p>
-        </section>
-
-        {/* ProblemSection — ダーク背景 */}
-        <section
-          className="py-20"
-          style={{ backgroundColor: "#141413" }}
-        >
-          <div className="mx-auto max-w-5xl px-6">
-            <h2
-              className="text-center text-3xl font-medium"
-              style={{
-                color: "#faf9f5",
-                fontFamily: "Georgia, serif",
-                lineHeight: 1.2,
-              }}
-            >
-              {problem.heading}
-            </h2>
-            <ul className="mx-auto mt-10 max-w-lg space-y-5">
-              {problem.items.map((item) => (
-                <li
-                  key={item}
-                  className="flex items-start gap-3 text-base leading-relaxed"
-                  style={{ color: "#b0aea5" }}
-                >
-                  <span
-                    className="mt-0.5 flex-shrink-0 text-sm"
-                    style={{ color: "#c96442" }}
-                  >
-                    ✕
-                  </span>
-                  {item}
-                </li>
-              ))}
-            </ul>
-          </div>
-        </section>
-
-        {/* HowItWorksSection */}
-        <section className="py-20" style={{ backgroundColor: "#f5f4ed" }}>
-          <div className="mx-auto max-w-5xl px-6">
-            <h2
-              className="text-center text-3xl font-medium"
-              style={{
-                color: "#141413",
-                fontFamily: "Georgia, serif",
-                lineHeight: 1.2,
-              }}
-            >
-              {howItWorks.heading}
-            </h2>
-            <div className="mx-auto mt-12 grid max-w-3xl grid-cols-1 gap-6 sm:grid-cols-3">
-              {howItWorks.steps.map(({ number, label }) => (
-                <div
-                  key={number}
-                  className="rounded-2xl p-6"
-                  style={{
-                    backgroundColor: "#faf9f5",
-                    border: "1px solid #f0eee6",
-                  }}
-                >
-                  <div
-                    className="mb-4 text-3xl font-medium"
-                    style={{
-                      color: "#c96442",
-                      fontFamily: "Georgia, serif",
-                    }}
-                  >
-                    {number}
-                  </div>
-                  <p
-                    className="text-base leading-relaxed"
-                    style={{ color: "#4d4c48" }}
-                  >
-                    {label}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* BenefitSection — ダーク背景 */}
-        <section className="py-20" style={{ backgroundColor: "#30302e" }}>
-          <div className="mx-auto max-w-5xl px-6">
-            <h2
-              className="text-center text-3xl font-medium"
-              style={{
-                color: "#faf9f5",
-                fontFamily: "Georgia, serif",
-                lineHeight: 1.2,
-              }}
-            >
-              {benefit.heading}
-            </h2>
-            <ul className="mx-auto mt-10 max-w-md space-y-5">
-              {benefit.items.map((item) => (
-                <li
-                  key={item}
-                  className="flex items-start gap-3 text-base leading-relaxed"
-                  style={{ color: "#b0aea5" }}
-                >
-                  <span
-                    className="mt-0.5 flex-shrink-0"
-                    style={{ color: "#c96442" }}
-                  >
-                    ✓
-                  </span>
-                  {item}
-                </li>
-              ))}
-            </ul>
-          </div>
-        </section>
-
-        {/* DifferenceSection */}
-        <section className="py-20" style={{ backgroundColor: "#f5f4ed" }}>
-          <div className="mx-auto max-w-5xl px-6 text-center">
-            <h2
-              className="text-3xl font-medium"
-              style={{
-                color: "#141413",
-                fontFamily: "Georgia, serif",
-                lineHeight: 1.2,
-              }}
-            >
-              {difference.heading}
-            </h2>
-            <p
-              className="mx-auto mt-4 max-w-lg text-base leading-relaxed"
-              style={{ color: "#5e5d59" }}
-            >
-              {difference.body}
-            </p>
-            {/* 価値ループ */}
-            <div className="mt-10 flex flex-wrap items-center justify-center gap-2">
-              {difference.loop.map((step, i) => (
-                <div key={step} className="flex items-center gap-2">
-                  <span
-                    className="rounded-full px-4 py-1.5 text-sm font-medium"
-                    style={{
-                      backgroundColor: "#faf9f5",
-                      border: "1px solid #e8e6dc",
-                      color: "#4d4c48",
-                    }}
-                  >
-                    {step}
-                  </span>
-                  {i < difference.loop.length - 1 && (
-                    <span style={{ color: "#c96442" }}>→</span>
-                  )}
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* BetaCtaSection */}
-        <section
-          className="py-24 text-center"
-          style={{ backgroundColor: "#141413" }}
-        >
-          <div className="mx-auto max-w-5xl px-6">
-            <h2
-              className="text-3xl font-medium sm:text-4xl"
-              style={{
-                color: "#faf9f5",
-                fontFamily: "Georgia, serif",
-                lineHeight: 1.2,
-              }}
-            >
-              {betaCta.heading}
-            </h2>
-            <p
-              className="mx-auto mt-4 max-w-lg text-base leading-relaxed"
-              style={{ color: "#b0aea5" }}
-            >
-              {betaCta.body}
-            </p>
-            <div className="mt-10">
-              <Link
-                href="/login"
-                className="inline-block rounded-lg px-8 py-3.5 text-base font-medium transition-opacity hover:opacity-90"
-                style={{ backgroundColor: "#c96442", color: "#faf9f5" }}
-              >
-                {betaCta.ctaLabel}
-              </Link>
-            </div>
-            <p className="mt-4 text-sm" style={{ color: "#87867f" }}>
-              {betaCta.note}
-            </p>
-          </div>
-        </section>
+        <HeroSection />
+        <ProblemSection />
+        <HowItWorksSection />
+        <BenefitSection />
+        <DifferenceSection />
+        <BetaCtaSection />
       </main>
 
       {/* フッター */}

--- a/src/app/_components/lp/ProblemSection.tsx
+++ b/src/app/_components/lp/ProblemSection.tsx
@@ -1,0 +1,43 @@
+import { LP_CONTENT } from "./content";
+
+/**
+ * ProblemSection — 課題共感を作るセクション（ダーク背景）
+ */
+export function ProblemSection() {
+  const { problem } = LP_CONTENT;
+
+  return (
+    <section className="py-20" style={{ backgroundColor: "#141413" }}>
+      <div className="mx-auto max-w-5xl px-6">
+        <h2
+          className="text-center text-3xl font-medium"
+          style={{
+            color: "#faf9f5",
+            fontFamily: "Georgia, serif",
+            lineHeight: 1.2,
+          }}
+        >
+          {problem.heading}
+        </h2>
+        <ul className="mx-auto mt-10 max-w-lg space-y-5">
+          {problem.items.map((item) => (
+            <li
+              key={item}
+              className="flex items-start gap-3 text-base leading-relaxed"
+              style={{ color: "#b0aea5" }}
+            >
+              <span
+                className="mt-0.5 flex-shrink-0 text-sm"
+                style={{ color: "#c96442" }}
+                aria-hidden="true"
+              >
+                ✕
+              </span>
+              {item}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## 概要

LP のセクション表示を個別コンポーネントに分割し、`LandingPage.tsx` の責務をレイアウトの束ね役に絞りました。
文言・デザインは変更せず、コンポーネント構成を `docs/LP.md` の仕様に合わせて整理しています。

## 関連 Issue

Closes #108

## 変更点

- `HeroSection.tsx` を新規作成：見出し・サブコピー・CTA・補助文
- `ProblemSection.tsx` を新規作成：課題共感リスト（ダーク背景）
- `HowItWorksSection.tsx` を新規作成：3ステップカードグリッド
- `BenefitSection.tsx` を新規作成：ベネフィットリスト（ダーク背景）
- `DifferenceSection.tsx` を新規作成：差分説明＋価値ループ
- `BetaCtaSection.tsx` を新規作成：下部 CTA（ダーク背景）
- `LandingPage.tsx` を変更：インライン実装を削除し、上記 6 コンポーネントを呼び出すレイアウトに整理

## 動作確認

- `LandingPage.tsx` の TypeScript エラーがないことを確認済み
- 文言・色・セクション順序は変更なし（表示上の差分なし）
