### PR TITLE
feat(lp): LP先行登録モーダル・フォーム・waitlist APIを実装

### DIFF
--- a/prisma/migrations/20260421000000_add_waitlist_entries/migration.sql
+++ b/prisma/migrations/20260421000000_add_waitlist_entries/migration.sql
@@ -1,0 +1,14 @@
+-- AddTable: waitlist_entries
+CREATE TABLE "waitlist_entries" (
+    "id"               UUID         NOT NULL DEFAULT gen_random_uuid(),
+    "email"            TEXT         NOT NULL,
+    "graduation_year"  INTEGER      NOT NULL,
+    "concerns"         TEXT,
+    "hearing_opt_in"   BOOLEAN,
+    "created_at"       TIMESTAMPTZ  NOT NULL DEFAULT now(),
+
+    CONSTRAINT "waitlist_entries_pkey" PRIMARY KEY ("id")
+);
+
+-- AddUniqueIndex: email
+CREATE UNIQUE INDEX "waitlist_entries_email_key" ON "waitlist_entries"("email");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -118,6 +118,18 @@ model NotificationDelivery {
   @@map("notification_deliveries")
 }
 
+/// LP先行登録エントリ
+model WaitlistEntry {
+  id              String    @id @default(uuid()) @db.Uuid
+  email           String    @unique
+  graduationYear  Int       @map("graduation_year")
+  concerns        String?
+  hearingOptIn    Boolean?  @map("hearing_opt_in")
+  createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz
+
+  @@map("waitlist_entries")
+}
+
 /// マジックリンク認証トークン（有効期限付き、使い捨て）
 model MagicLinkToken {
   id        String    @id @default(uuid()) @db.Uuid

--- a/src/app/_components/lp/BetaCtaSection.tsx
+++ b/src/app/_components/lp/BetaCtaSection.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { LP_CONTENT } from "./content";
+import { LeadCaptureDialog } from "./LeadCaptureDialog";
 
 /**
  * BetaCtaSection — 下部の登録導線セクション（ダーク背景）
@@ -31,13 +31,7 @@ export function BetaCtaSection() {
           {betaCta.body}
         </p>
         <div className="mt-10">
-          <Link
-            href="/login"
-            className="inline-block rounded-lg px-8 py-3.5 text-base font-medium transition-opacity hover:opacity-90"
-            style={{ backgroundColor: "#c96442", color: "#faf9f5" }}
-          >
-            {betaCta.ctaLabel}
-          </Link>
+          <LeadCaptureDialog label={betaCta.ctaLabel} ctaLocation="bottom" dark />
         </div>
         <p className="mt-4 text-sm" style={{ color: "#87867f" }}>
           {betaCta.note}

--- a/src/app/_components/lp/HeroSection.tsx
+++ b/src/app/_components/lp/HeroSection.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { LP_CONTENT } from "./content";
+import { LeadCaptureDialog } from "./LeadCaptureDialog";
 
 /**
  * HeroSection — 誰向けの価値かを最初に伝えるセクション
@@ -27,13 +27,7 @@ export function HeroSection() {
         {hero.subCopy}
       </p>
       <div className="mt-10">
-        <Link
-          href="/login"
-          className="inline-block rounded-lg px-8 py-3.5 text-base font-medium transition-opacity hover:opacity-90"
-          style={{ backgroundColor: "#c96442", color: "#faf9f5" }}
-        >
-          {hero.ctaLabel}
-        </Link>
+        <LeadCaptureDialog label={hero.ctaLabel} ctaLocation="hero" />
       </div>
       <p className="mt-4 text-sm" style={{ color: "#87867f" }}>
         {hero.note}

--- a/src/app/_components/lp/LeadCaptureComplete.tsx
+++ b/src/app/_components/lp/LeadCaptureComplete.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+/**
+ * LeadCaptureComplete — 先行登録完了状態の表示
+ * docs/LP.md § LeadCaptureComplete に準拠
+ */
+
+interface LeadCaptureCompleteProps {
+  onClose: () => void;
+}
+
+export function LeadCaptureComplete({ onClose }: LeadCaptureCompleteProps) {
+  return (
+    <div className="flex flex-col items-center gap-4 text-center">
+      <h2
+        className="text-2xl font-medium"
+        style={{ color: "#141413", fontFamily: "Georgia, serif", lineHeight: 1.2 }}
+      >
+        登録ありがとうございます
+      </h2>
+      <p className="text-base leading-relaxed" style={{ color: "#5e5d59" }}>
+        〆トラは現在、先行案内・検証段階です。
+        <br />
+        今後、ベータ版やヒアリングのご案内を順次お送りします。
+      </p>
+      <p className="text-sm" style={{ color: "#87867f" }}>
+        就活の悩みはご入力内容を参考に改善へ活用します。
+      </p>
+      <button
+        type="button"
+        onClick={onClose}
+        className="mt-2 rounded-lg px-8 py-3 text-sm font-medium transition-opacity hover:opacity-90"
+        style={{ backgroundColor: "#e8e6dc", color: "#4d4c48" }}
+      >
+        LPに戻る
+      </button>
+    </div>
+  );
+}

--- a/src/app/_components/lp/LeadCaptureDialog.tsx
+++ b/src/app/_components/lp/LeadCaptureDialog.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+/**
+ * LeadCaptureDialog — 先行登録モーダル
+ *
+ * 開閉状態・フォーム/完了切り替えを管理する Client Component。
+ * HeroSection / BetaCtaSection のCTAボタンとして差し込む。
+ *
+ * docs/LP.md § LeadCaptureDialog に準拠
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { LeadCaptureForm } from "./LeadCaptureForm";
+import { LeadCaptureComplete } from "./LeadCaptureComplete";
+
+/** window.dataLayer push helper */
+function pushDataLayer(payload: Record<string, unknown>) {
+  const win = window as Window & { dataLayer?: unknown[] };
+  win.dataLayer = win.dataLayer ?? [];
+  win.dataLayer.push(payload);
+}
+
+interface LeadCaptureDialogProps {
+  /** CTA ボタンのラベル */
+  label?: string;
+  /** 計測用: どこのCTAから開いたか */
+  ctaLocation?: "hero" | "bottom";
+  /** ダークテーマ用（BetaCtaSection など） */
+  dark?: boolean;
+}
+
+export function LeadCaptureDialog({
+  label = "先行利用に登録する",
+  ctaLocation = "hero",
+  dark = false,
+}: LeadCaptureDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleOpen = useCallback(() => {
+    setOpen(true);
+    setSubmitted(false);
+
+    pushDataLayer({
+      event:
+        ctaLocation === "hero"
+          ? "lp_primary_cta_clicked"
+          : "lp_secondary_cta_clicked",
+      cta_location: ctaLocation,
+      cta_label: label,
+      page_type: "lp",
+    });
+
+    pushDataLayer({
+      event: "lp_waitlist_form_opened",
+      open_source: ctaLocation,
+      page_type: "lp",
+    });
+  }, [ctaLocation, label]);
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  const handleSuccess = useCallback(() => {
+    setSubmitted(true);
+  }, []);
+
+  // ESC で閉じる
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") handleClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open, handleClose]);
+
+  // 開放中はスクロールを抑制
+  useEffect(() => {
+    document.body.style.overflow = open ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  const buttonBg = dark ? "#c96442" : "#c96442";
+  const buttonColor = "#faf9f5";
+
+  return (
+    <>
+      {/* トリガーボタン */}
+      <button
+        type="button"
+        onClick={handleOpen}
+        className="inline-block rounded-lg px-8 py-3.5 text-base font-medium transition-opacity hover:opacity-90"
+        style={{ backgroundColor: buttonBg, color: buttonColor }}
+      >
+        {label}
+      </button>
+
+      {/* モーダルオーバーレイ */}
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-end justify-center sm:items-center p-4"
+          style={{ backgroundColor: "rgba(20,20,19,0.6)" }}
+          aria-modal="true"
+          role="dialog"
+          aria-label="先行登録フォーム"
+          onClick={(e) => {
+            // オーバーレイ自体クリックで閉じる
+            if (e.target === e.currentTarget) handleClose();
+          }}
+        >
+          <div
+            className="relative w-full max-w-md rounded-2xl p-6 sm:p-8"
+            style={{ backgroundColor: "#faf9f5" }}
+          >
+            {/* 閉じるボタン */}
+            <button
+              type="button"
+              onClick={handleClose}
+              aria-label="閉じる"
+              className="absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-full text-xl transition-opacity hover:opacity-70"
+              style={{ color: "#87867f" }}
+            >
+              ×
+            </button>
+
+            {submitted ? (
+              <LeadCaptureComplete onClose={handleClose} />
+            ) : (
+              <>
+                <h2
+                  className="mb-1 text-xl font-medium"
+                  style={{
+                    color: "#141413",
+                    fontFamily: "Georgia, serif",
+                    lineHeight: 1.2,
+                  }}
+                >
+                  登録して案内を受け取る
+                </h2>
+                <p className="mb-6 text-sm" style={{ color: "#87867f" }}>
+                  正式公開前の先行案内です
+                </p>
+                <LeadCaptureForm onSuccess={handleSuccess} />
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/_components/lp/LeadCaptureForm.tsx
+++ b/src/app/_components/lp/LeadCaptureForm.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+/**
+ * LeadCaptureForm — 先行登録フォーム
+ * docs/LP.md § LeadCaptureForm に準拠
+ *
+ * - メールアドレス（必須）
+ * - 卒業年度（必須）
+ * - 今の悩み（任意）
+ * - ヒアリング参加可否（任意）
+ */
+
+import { useState } from "react";
+
+/** window.dataLayer push helper（型は最小限） */
+function pushDataLayer(payload: Record<string, unknown>) {
+  const win = window as Window & { dataLayer?: unknown[] };
+  win.dataLayer = win.dataLayer ?? [];
+  win.dataLayer.push(payload);
+}
+
+const CURRENT_YEAR = new Date().getFullYear();
+const GRADUATION_YEARS = Array.from({ length: 6 }, (_, i) => CURRENT_YEAR + i);
+
+interface LeadCaptureFormProps {
+  onSuccess: () => void;
+}
+
+export function LeadCaptureForm({ onSuccess }: LeadCaptureFormProps) {
+  const [email, setEmail] = useState("");
+  const [graduationYear, setGraduationYear] = useState<string>(
+    String(CURRENT_YEAR + 1),
+  );
+  const [concerns, setConcerns] = useState("");
+  const [hearingOptIn, setHearingOptIn] = useState<boolean | undefined>(undefined);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    // ── クライアントサイドバリデーション ────────────────────────────
+    const emailTrimmed = email.trim();
+    if (!emailTrimmed) {
+      setError("メールアドレスを入力してください");
+      pushDataLayer({
+        event: "lp_waitlist_submit_failed",
+        form_type: "waitlist",
+        error_type: "validation",
+        page_type: "lp",
+      });
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailTrimmed)) {
+      setError("正しいメールアドレスを入力してください");
+      pushDataLayer({
+        event: "lp_waitlist_submit_failed",
+        form_type: "waitlist",
+        error_type: "validation",
+        page_type: "lp",
+      });
+      return;
+    }
+
+    setPending(true);
+
+    try {
+      const res = await fetch("/api/waitlist", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: emailTrimmed,
+          graduationYear: Number(graduationYear),
+          concerns: concerns.trim() || undefined,
+          hearingOptIn: hearingOptIn,
+        }),
+      });
+
+      if (res.ok) {
+        pushDataLayer({
+          event: "lp_waitlist_submitted",
+          form_type: "waitlist",
+          graduation_year: Number(graduationYear),
+          hearing_opt_in: hearingOptIn ?? null,
+          page_type: "lp",
+        });
+        onSuccess();
+        return;
+      }
+
+      const data = await res.json().catch(() => ({})) as { error?: string };
+      const msg =
+        res.status === 409
+          ? "このメールアドレスはすでに登録されています"
+          : (data.error ?? "送信に失敗しました。しばらく後にお試しください");
+
+      setError(msg);
+      pushDataLayer({
+        event: "lp_waitlist_submit_failed",
+        form_type: "waitlist",
+        error_type: res.status === 409 ? "duplicate" : "api_error",
+        page_type: "lp",
+      });
+    } catch {
+      setError("送信に失敗しました。しばらく後にお試しください");
+      pushDataLayer({
+        event: "lp_waitlist_submit_failed",
+        form_type: "waitlist",
+        error_type: "network_error",
+        page_type: "lp",
+      });
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-5">
+      {/* メールアドレス */}
+      <div className="flex flex-col gap-1.5">
+        <label className="text-sm font-medium" style={{ color: "#4d4c48" }}>
+          メールアドレス <span style={{ color: "#b53333" }}>*</span>
+        </label>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="example@email.com"
+          required
+          autoComplete="email"
+          className="w-full rounded-lg border px-4 py-2.5 text-sm outline-none transition-shadow focus:ring-2"
+          style={{
+            borderColor: "#e8e6dc",
+            backgroundColor: "#faf9f5",
+            color: "#141413",
+          }}
+        />
+      </div>
+
+      {/* 卒業年度 */}
+      <div className="flex flex-col gap-1.5">
+        <label className="text-sm font-medium" style={{ color: "#4d4c48" }}>
+          卒業年度 <span style={{ color: "#b53333" }}>*</span>
+        </label>
+        <select
+          value={graduationYear}
+          onChange={(e) => setGraduationYear(e.target.value)}
+          className="w-full rounded-lg border px-4 py-2.5 text-sm outline-none transition-shadow focus:ring-2"
+          style={{
+            borderColor: "#e8e6dc",
+            backgroundColor: "#faf9f5",
+            color: "#141413",
+          }}
+        >
+          {GRADUATION_YEARS.map((y) => (
+            <option key={y} value={y}>
+              {y}年3月卒
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* 今の悩み（任意） */}
+      <div className="flex flex-col gap-1.5">
+        <label className="text-sm font-medium" style={{ color: "#4d4c48" }}>
+          今の悩み{" "}
+          <span className="text-xs font-normal" style={{ color: "#87867f" }}>
+            （任意）
+          </span>
+        </label>
+        <textarea
+          value={concerns}
+          onChange={(e) => setConcerns(e.target.value)}
+          rows={3}
+          placeholder="例：自己分析が終わらない、どの業界を見ればいいかわからない…"
+          className="w-full rounded-lg border px-4 py-2.5 text-sm outline-none transition-shadow focus:ring-2 resize-none"
+          style={{
+            borderColor: "#e8e6dc",
+            backgroundColor: "#faf9f5",
+            color: "#141413",
+          }}
+        />
+      </div>
+
+      {/* ヒアリング参加可否（任意） */}
+      <div className="flex flex-col gap-2">
+        <span className="text-sm font-medium" style={{ color: "#4d4c48" }}>
+          ヒアリング参加可否{" "}
+          <span className="text-xs font-normal" style={{ color: "#87867f" }}>
+            （任意）
+          </span>
+        </span>
+        <div className="flex gap-6">
+          <label className="flex items-center gap-2 cursor-pointer text-sm" style={{ color: "#5e5d59" }}>
+            <input
+              type="radio"
+              name="hearingOptIn"
+              checked={hearingOptIn === true}
+              onChange={() => setHearingOptIn(true)}
+              className="accent-current"
+            />
+            はい
+          </label>
+          <label className="flex items-center gap-2 cursor-pointer text-sm" style={{ color: "#5e5d59" }}>
+            <input
+              type="radio"
+              name="hearingOptIn"
+              checked={hearingOptIn === false}
+              onChange={() => setHearingOptIn(false)}
+              className="accent-current"
+            />
+            いいえ
+          </label>
+        </div>
+      </div>
+
+      {/* エラー表示 */}
+      {error && (
+        <p className="text-sm" style={{ color: "#b53333" }}>
+          {error}
+        </p>
+      )}
+
+      {/* 送信ボタン */}
+      <button
+        type="submit"
+        disabled={pending}
+        className="w-full rounded-lg px-6 py-3 text-sm font-medium transition-opacity hover:opacity-90 disabled:opacity-50"
+        style={{ backgroundColor: "#c96442", color: "#faf9f5" }}
+      >
+        {pending ? "送信中..." : "登録して案内を受け取る"}
+      </button>
+
+      <p className="text-center text-xs" style={{ color: "#87867f" }}>
+        無料です / 後日ご案内します
+      </p>
+    </form>
+  );
+}

--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -1,0 +1,98 @@
+/**
+ * POST /api/waitlist
+ *
+ * LP先行登録エンドポイント
+ *
+ * 認証: 不要（公開エンドポイント）
+ *
+ * リクエストボディ:
+ *  - email          : string（必須）
+ *  - graduationYear : number（必須、4桁）
+ *  - concerns       : string | undefined（任意）
+ *  - hearingOptIn   : boolean | undefined（任意）
+ *
+ * レスポンス:
+ *  - { ok: true }          200
+ *  - { error: string }     400 / 409 / 500
+ *
+ * 制約:
+ *  - メールアドレスの重複は 409 を返す
+ *  - バリデーション失敗は 400 を返す
+ *  - メールアドレスは計測イベントに含めない
+ */
+
+export const runtime = "edge";
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const CURRENT_YEAR = new Date().getFullYear();
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json().catch(() => ({}));
+
+    const { email, graduationYear, concerns, hearingOptIn } = body as {
+      email?: unknown;
+      graduationYear?: unknown;
+      concerns?: unknown;
+      hearingOptIn?: unknown;
+    };
+
+    // ── バリデーション ─────────────────────────────────────────────────
+    if (typeof email !== "string" || !EMAIL_REGEX.test(email)) {
+      return NextResponse.json(
+        { error: "メールアドレスを正しく入力してください" },
+        { status: 400 },
+      );
+    }
+
+    const year = Number(graduationYear);
+    if (!Number.isInteger(year) || year < CURRENT_YEAR || year > CURRENT_YEAR + 10) {
+      return NextResponse.json(
+        { error: "卒業年度を正しく選択してください" },
+        { status: 400 },
+      );
+    }
+
+    if (concerns !== undefined && typeof concerns !== "string") {
+      return NextResponse.json({ error: "入力値が不正です" }, { status: 400 });
+    }
+
+    if (hearingOptIn !== undefined && typeof hearingOptIn !== "boolean") {
+      return NextResponse.json({ error: "入力値が不正です" }, { status: 400 });
+    }
+
+    // ── 保存 ─────────────────────────────────────────────────────────
+    await prisma.waitlistEntry.create({
+      data: {
+        email: email.trim().toLowerCase(),
+        graduationYear: year,
+        concerns: typeof concerns === "string" && concerns.trim() ? concerns.trim() : null,
+        hearingOptIn: typeof hearingOptIn === "boolean" ? hearingOptIn : null,
+      },
+    });
+
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (err: unknown) {
+    // Prisma unique constraint violation
+    if (
+      err instanceof Error &&
+      "code" in err &&
+      (err as { code: string }).code === "P2002"
+    ) {
+      return NextResponse.json(
+        { error: "このメールアドレスはすでに登録されています" },
+        { status: 409 },
+      );
+    }
+
+    console.error("[waitlist] unexpected error", err);
+    return NextResponse.json(
+      { error: "送信に失敗しました。しばらく後にお試しください" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## 概要

LP からの先行登録導線として、登録モーダル・フォーム・完了状態と `POST /api/waitlist` を実装しました。
`docs/LP.md` の仕様に沿い、Hero / 下部 CTA から waitlist 登録を完了できる状態にしています。

## 関連 Issue

Closes #109

## 変更点

### DB・API
- `prisma/schema.prisma` に `WaitlistEntry` モデルを追加
- `prisma/migrations/20260421000000_add_waitlist_entries/migration.sql` を追加（`waitlist_entries` テーブル作成）
- `POST /api/waitlist` を新設
  - メールアドレス・卒業年度の必須バリデーション
  - 重複メール登録は `409` を返す
  - バリデーション失敗（`400`）と API 失敗（`5xx`）を区別

### フロントエンド（3コンポーネント追加）
- `LeadCaptureDialog.tsx` — 開閉状態・フォーム/完了切り替えを管理するモーダル（Client Component）
  - ESC キー・オーバーレイクリックで閉じる
  - モバイルはボトムシート風、PC は中央ダイアログ
- `LeadCaptureForm.tsx` — 入力・バリデーション・API 送信（Client Component）
  - メールアドレス、卒業年度（必須）、今の悩み、ヒアリング参加可否（任意）
  - `dataLayer.push` による計測イベント送信（`lp_waitlist_submitted` / `lp_waitlist_submit_failed`）
  - `error_type` でバリデーション失敗・重複・API エラーを区別
- `LeadCaptureComplete.tsx` — 登録完了後の期待値調整画面

### 既存コンポーネント修正
- `HeroSection.tsx`・`BetaCtaSection.tsx` の CTA を `/login` への `Link` から `LeadCaptureDialog` に変更（Server Component の構造は維持）

### 計測
- `lp_primary_cta_clicked` / `lp_secondary_cta_clicked` / `lp_waitlist_form_opened` / `lp_waitlist_submitted` / `lp_waitlist_submit_failed` を `dataLayer.push` で送信
- メールアドレスは計測イベントに含めない

## 動作確認

- TypeScript 型チェック: エラーなし（`npx tsc --noEmit`）
- 既存テスト: 107 件全通過（`npm run test`）
- DB マイグレーション適用後に実動作確認が必要（`prisma db push` または `prisma migrate deploy`）
