### PR TITLE
feat(waitlist): ウェイトリスト登録完了メールの自動送信を実装

### DIFF
--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -25,6 +25,7 @@ export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { sendEmail } from "@/lib/mailer";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const CURRENT_YEAR = new Date().getFullYear();
@@ -72,6 +73,42 @@ export async function POST(req: NextRequest) {
         concerns: typeof concerns === "string" && concerns.trim() ? concerns.trim() : null,
         hearingOptIn: typeof hearingOptIn === "boolean" ? hearingOptIn : null,
       },
+    });
+
+    // ── 登録完了メール送信（失敗してもコア処理には影響させない） ────────
+    sendEmail({
+      to: email.trim().toLowerCase(),
+      subject: "〆トラ 先行利用のご登録ありがとうございます",
+      html: `
+        <div style="font-family:sans-serif;max-width:480px;margin:0 auto;color:#222222;">
+          <h1 style="font-size:20px;font-weight:600;margin-bottom:16px;">ご登録ありがとうございます 🎉</h1>
+          <p style="line-height:1.7;margin-bottom:12px;">
+            〆トラの先行利用にご登録いただきありがとうございます。<br>
+            サービス開始の準備が整いましたら、このメールアドレスへご案内をお送りします。
+          </p>
+          <p style="line-height:1.7;margin-bottom:24px;">
+            もうしばらくお待ちください。引き続きよろしくお願いいたします。
+          </p>
+          <hr style="border:none;border-top:1px solid #dddddd;margin-bottom:16px;">
+          <p style="font-size:12px;color:#6a6a6a;">
+            〆トラ サポートチーム<br>
+            ご不明な点は <a href="mailto:support@shimetra.com" style="color:#ff385c;">support@shimetra.com</a> までお問い合わせください。
+          </p>
+        </div>
+      `,
+      text: [
+        "ご登録ありがとうございます。",
+        "",
+        "〆トラの先行利用にご登録いただきありがとうございます。",
+        "サービス開始の準備が整いましたら、このメールアドレスへご案内をお送りします。",
+        "",
+        "もうしばらくお待ちください。引き続きよろしくお願いいたします。",
+        "",
+        "〆トラ サポートチーム",
+        "support@shimetra.com",
+      ].join("\n"),
+    }).catch((err) => {
+      console.error("[waitlist] 登録完了メール送信エラー", err);
     });
 
     return NextResponse.json({ ok: true }, { status: 200 });


### PR DESCRIPTION
## 概要

ウェイトリスト登録完了後に、登録者へ自動で「登録ありがとうございます」メールを送信する機能を実装しました。

## 関連Issue

Closes #119

## 変更点

- `POST /api/waitlist` のDB保存処理の直後に `sendEmail()` を呼び出しを追加
- HTML本文とテキスト本文の両形式でメールを送信
- `sendEmail().catch(...)` で非同期処理し、送信失敗がコア処理（200レスポンス）に影響しない設計

## 動作確認

- `EMAIL_PROVIDER=console`（ローカル環境）では、サーバーコンソールにメール内容が出力されることを確認
- TypeScriptの型チェック（`tsc --noEmit`）でエラーなし
