### PR TITLE
feat(seo): robots.tsとsitemap.tsを追加してクロール方針を明示

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,29 @@
+import type { MetadataRoute } from "next";
+import { env } from "@/lib/env";
+
+/**
+ * /robots.txt を動的生成する。
+ *
+ * - production 環境: クロール・インデックスを許可
+ * - それ以外（preview / staging / development）: noindex で保護
+ */
+export default function robots(): MetadataRoute.Robots {
+  const isProduction = env.NODE_ENV === "production";
+
+  if (!isProduction) {
+    return {
+      rules: {
+        userAgent: "*",
+        disallow: "/",
+      },
+    };
+  }
+
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${env.APP_URL}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,46 @@
+import type { MetadataRoute } from "next";
+import { env } from "@/lib/env";
+
+/**
+ * /sitemap.xml を動的生成する。
+ *
+ * 出力するURL: / (トップ)、/lp、/terms、/privacy、/legal
+ * - /lp を最高優先度 (priority: 1.0) に設定
+ * - 主要ページは changeFrequency: "monthly"
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = env.APP_URL;
+
+  return [
+    {
+      url: `${baseUrl}/`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/lp`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1.0,
+    },
+    {
+      url: `${baseUrl}/terms`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.3,
+    },
+    {
+      url: `${baseUrl}/privacy`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.3,
+    },
+    {
+      url: `${baseUrl}/legal`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.3,
+    },
+  ];
+}


### PR DESCRIPTION
## 概要

Googleなどの検索エンジンに対してクロール方針とサイトマップを明示するため、`robots.ts` と `sitemap.ts` を新規追加しました。

## 関連Issue

Closes #122

## 変更点

- **`src/app/robots.ts`（新規）**
  - `production` 環境では `allow: "/"` + `sitemap` URLを出力
  - それ以外の環境（preview / staging / development）では `disallow: "/"` で noindex 保護
  - `env.NODE_ENV` / `env.APP_URL` を利用して絶対URLを生成

- **`src/app/sitemap.ts`（新規）**
  - 出力URL: `/`、`/lp`、`/terms`、`/privacy`、`/legal`
  - `/lp` を最高優先度（`priority: 1.0`）、他は `0.3〜0.9`
  - `changeFrequency: "monthly"` で統一
  - `env.APP_URL` で絶対URLを生成

## 動作確認

- [ ] 本番デプロイ後、`https://shimetra.com/robots.txt` でクロール許可が表示される
- [ ] 本番デプロイ後、`https://shimetra.com/sitemap.xml` で5件のURLが出力される
- [ ] preview環境では `/robots.txt` が `Disallow: /` を返す
