### PR TITLE
feat(auth): 認証後グローバルヘッダーとログアウト機能を実装する

### DIFF
--- a/src/app/_components/AppHeader.tsx
+++ b/src/app/_components/AppHeader.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+interface AppHeaderProps {
+  email: string;
+}
+
+export function AppHeader({ email }: AppHeaderProps) {
+  const router = useRouter();
+  const displayEmail = email.length > 20 ? email.slice(0, 20) + "…" : email;
+
+  async function handleLogout() {
+    await fetch("/api/auth/logout", { method: "POST" });
+    router.push("/");
+  }
+
+  return (
+    <header className="border-b border-slate-100">
+      <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
+        <Link href="/dashboard" className="text-lg font-bold text-slate-900">
+          〆トラ
+        </Link>
+        <div className="flex items-center gap-4">
+          <span className="text-sm text-slate-600" title={email}>
+            {displayEmail}
+          </span>
+          <button
+            onClick={handleLogout}
+            className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          >
+            ログアウト
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+import { clearSession } from "@/features/auth/session";
+
+export async function POST(req: Request) {
+  await clearSession();
+  return NextResponse.redirect(new URL("/", req.url));
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { GtmScript } from "./_components/GtmScript";
+import { AppHeader } from "./_components/AppHeader";
+import { getSession } from "@/features/auth/session";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -11,14 +13,17 @@ export const metadata: Metadata = {
   ),
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
+  const session = await getSession();
+
   return (
     <html lang="ja">
       <body className="flex min-h-screen flex-col">
         {/* GTM スクリプト: body 先頭に配置（noscript フォールバック含む） */}
         <GtmScript />
+        {session && <AppHeader email={session.email} />}
         <div className="flex-1">{children}</div>
         <footer className="border-t border-slate-200 bg-slate-50 py-4 text-center text-xs text-slate-500">
           <nav className="space-x-4">

--- a/src/features/auth/session.ts
+++ b/src/features/auth/session.ts
@@ -84,3 +84,9 @@ export function sessionCookieOptions(token: string) {
     maxAge: 60 * 60 * 24 * SESSION_DURATION_DAYS,
   };
 }
+
+/** セッション Cookie を削除する */
+export async function clearSession(): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.delete(SESSION_COOKIE);
+}


### PR DESCRIPTION
## 概要

ログイン後のページにグローバルナビゲーションがなく、ログアウト機能も存在しなかった問題を解消する。

Closes #131

## 変更点

- `src/features/auth/session.ts` — `clearSession()` を追加（セッションCookieを削除する）
- `src/app/api/auth/logout/route.ts` — 新規作成。`POST` で `clearSession()` を呼び `/` へリダイレクト
- `src/app/_components/AppHeader.tsx` — 新規作成。認証済みユーザー向けグローバルヘッダー（`/dashboard` リンク・メールアドレス省略表示・ログアウトボタン）
- `src/app/layout.tsx` — `getSession()` でセッション確認し、認証済みの場合のみ `<AppHeader>` を表示

## 動作確認チェックリスト

- [ ] ログイン後のページ（`/dashboard` 等）にヘッダーが表示される
- [ ] ヘッダー左の「〆トラ」クリックで `/dashboard` に遷移する
- [ ] メールアドレスが20文字を超える場合に省略表示される
- [ ] ログアウトボタン押下後、Cookieが削除されて `/` へリダイレクトされる
- [ ] 未認証ページ（`/`, `/login` 等）にヘッダーが表示されない
- [ ] `npx tsc --noEmit` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)
