### PR TITLE
ux(dashboard): ステータスバッジ・緊急度表示・件数サマリーを追加する

### DIFF
--- a/src/app/dashboard/DeadlineList.tsx
+++ b/src/app/dashboard/DeadlineList.tsx
@@ -8,6 +8,7 @@ import {
   URGENCY_CLASS,
   KIND_LABEL,
   STATUS_LABEL,
+  STATUS_COLOR,
 } from "@/features/deadlines/format";
 
 export type DeadlineItem = {
@@ -36,6 +37,7 @@ export default function DeadlineList({ initialItems }: Props) {
   const [updatingId, setUpdatingId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [editingStatusId, setEditingStatusId] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   function handleDelete(id: string) {
@@ -178,21 +180,37 @@ export default function DeadlineList({ initialItems }: Props) {
                   )}
                 </div>
 
-                {/* 右列：ステータスセレクト（1操作で即更新）＋編集リンク＋削除ボタン */}
+                {/* 右列：ステータス＋編集リンク＋削除ボタン */}
                 <div className="flex shrink-0 items-center gap-2">
-                <select
-                  value={item.status}
-                  disabled={isUpdating || isDeleting}
-                  onChange={(e) => handleStatusChange(item.id, e.target.value)}
-                  aria-label={`${item.companyName}のステータスを変更`}
-                  className="cursor-pointer rounded border border-slate-200 bg-white px-2 py-1 text-sm text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  {Object.entries(STATUS_LABEL).map(([value, label]) => (
-                    <option key={value} value={value}>
-                      {label}
-                    </option>
-                  ))}
-                </select>
+                {editingStatusId === item.id ? (
+                  <select
+                    value={item.status}
+                    autoFocus
+                    disabled={isUpdating || isDeleting}
+                    onChange={(e) => {
+                      handleStatusChange(item.id, e.target.value);
+                      setEditingStatusId(null);
+                    }}
+                    onBlur={() => setEditingStatusId(null)}
+                    aria-label={`${item.companyName}のステータスを変更`}
+                    className="cursor-pointer rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {Object.entries(STATUS_LABEL).map(([value, label]) => (
+                      <option key={value} value={value}>
+                        {label}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <button
+                    onClick={() => setEditingStatusId(item.id)}
+                    disabled={isUpdating || isDeleting}
+                    aria-label={`${item.companyName}のステータスを変更`}
+                    className={`rounded px-2 py-1 text-xs font-medium ${STATUS_COLOR[item.status]} disabled:cursor-not-allowed disabled:opacity-50`}
+                  >
+                    {STATUS_LABEL[item.status]}
+                  </button>
+                )}
                 <Link
                   href={`/deadline/${item.id}/edit`}
                   aria-label={`${item.companyName}を編集`}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/prisma";
 import DeadlineList, { type DeadlineItem } from "./DeadlineList";
 import { FREE_ITEM_LIMIT, isProUser } from "@/features/deadlines/gate";
 import { trackEvent } from "@/features/analytics";
+import { getUrgencyLevel } from "@/features/deadlines/format";
 
 /**
  * /dashboard – Server Component
@@ -50,6 +51,11 @@ export default async function DashboardPage() {
   // Free ユーザーが上限に達しているか
   const isAtFreeLimit = !pro && items.length >= FREE_ITEM_LIMIT;
 
+  const todoCount = items.filter((i) => i.status === "todo").length;
+  const overdueCount = items.filter(
+    (i) => i.status === "todo" && getUrgencyLevel(i.deadlineAt) === "overdue",
+  ).length;
+
   return (
     <main className="mx-auto max-w-3xl p-6">
       {/* ヘッダー */}
@@ -62,6 +68,36 @@ export default async function DashboardPage() {
           + 締切を追加
         </Link>
       </div>
+
+      {/* 件数サマリー */}
+      {items.length > 0 && (
+        <div className="mt-4 grid grid-cols-3 gap-3">
+          <div className="rounded-lg border border-slate-200 bg-white px-4 py-3 text-center">
+            <p className="text-2xl font-bold text-slate-900">{items.length}</p>
+            <p className="mt-0.5 text-xs text-slate-500">登録中</p>
+          </div>
+          <div className="rounded-lg border border-slate-200 bg-white px-4 py-3 text-center">
+            <p className="text-2xl font-bold text-slate-900">{todoCount}</p>
+            <p className="mt-0.5 text-xs text-slate-500">未対応</p>
+          </div>
+          <div
+            className={`rounded-lg border px-4 py-3 text-center ${
+              overdueCount > 0
+                ? "border-red-200 bg-red-50"
+                : "border-slate-200 bg-white"
+            }`}
+          >
+            <p
+              className={`text-2xl font-bold ${
+                overdueCount > 0 ? "text-red-600" : "text-slate-900"
+              }`}
+            >
+              {overdueCount}
+            </p>
+            <p className="mt-0.5 text-xs text-slate-500">期限切れ</p>
+          </div>
+        </div>
+      )}
 
       {/* Free 枠上限バナー */}
       {isAtFreeLimit && (

--- a/src/features/deadlines/format.ts
+++ b/src/features/deadlines/format.ts
@@ -71,3 +71,10 @@ export const STATUS_LABEL: Record<string, string> = {
   done: "完了",
   canceled: "辞退/中止",
 };
+
+export const STATUS_COLOR: Record<string, string> = {
+  todo: "bg-slate-100 text-slate-600",
+  submitted: "bg-blue-100 text-blue-700",
+  done: "bg-green-100 text-green-700",
+  canceled: "bg-slate-100 text-slate-400",
+};


### PR DESCRIPTION
## 概要

ダッシュボードのUI/UXを改善する。ステータスをバッジ表示に変更し、件数サマリーを追加する。

Closes #134

## 変更点

**`src/features/deadlines/format.ts`**
- `STATUS_COLOR` マップを追加（todo=グレー / submitted=青 / done=緑 / canceled=グレー薄）

**`src/app/dashboard/DeadlineList.tsx`**
- `editingStatusId: string | null` state を追加
- 通常時: ステータスを色付きバッジで表示（`STATUS_COLOR` を使用）
- バッジクリック時: `<select>` に切り替わって編集可能（選択後またはblurで自動的にバッジに戻る）

**`src/app/dashboard/page.tsx`**
- `getUrgencyLevel` をインポートして期限切れ件数を計算
- アイテムが1件以上ある場合、ヘッダー直下に3カラムのサマリーを表示
  - 「登録中」: 全件数
  - 「未対応」: status=todo の件数
  - 「期限切れ」: status=todo かつ期限切れの件数（0より多い場合は赤でハイライト）

## 動作確認

- [x] ダッシュボードのアイテムにステータスがバッジ（色付き）で表示される
- [x] バッジをクリックすると `<select>` に切り替わり、ステータスを変更できる
- [x] ステータス変更後・フォーカスが外れるとバッジ表示に戻る
- [x] ヘッダー下に「登録中 / 未対応 / 期限切れ」の3カラムサマリーが表示される
- [x] 期限切れアイテムがある場合、「期限切れ」カードが赤でハイライトされる
- [x] アイテムが0件の場合、サマリーは表示されない
