### PR TITLE
fix(layout): パブリックページでAppHeaderが二重表示されるバグを修正

### DIFF
--- a/src/app/_components/ConditionalHeader.tsx
+++ b/src/app/_components/ConditionalHeader.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { AppHeader } from "./AppHeader";
+
+const PUBLIC_PATHS = ["/", "/login", "/terms", "/privacy", "/legal"];
+
+export function ConditionalHeader({ email }: { email: string }) {
+  const pathname = usePathname();
+  if (PUBLIC_PATHS.includes(pathname)) return null;
+  return <AppHeader email={email} />;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { GtmScript } from "./_components/GtmScript";
-import { AppHeader } from "./_components/AppHeader";
+import { ConditionalHeader } from "./_components/ConditionalHeader";
 import { getSession } from "@/features/auth/session";
 import "./globals.css";
 
@@ -23,7 +23,7 @@ export default async function RootLayout({
       <body className="flex min-h-screen flex-col">
         {/* GTM スクリプト: body 先頭に配置（noscript フォールバック含む） */}
         <GtmScript />
-        {session && <AppHeader email={session.email} />}
+        {session && <ConditionalHeader email={session.email} />}
         <div className="flex-1">{children}</div>
         <footer className="border-t border-slate-200 bg-slate-50 py-4 text-center text-xs text-slate-500">
           <nav className="space-x-4">


### PR DESCRIPTION
## 概要

ログイン済みユーザーがトップページ（`/`）にアクセスした際に、グローバルヘッダー（`AppHeader`）とページ内ヘッダーが二重表示されるバグを修正する。

## 関連Issue

Closes #140

## 変更点

### `src/app/_components/ConditionalHeader.tsx`（新規）

- `usePathname()` を使用する Client Component ラッパーを新規作成
- `/`、`/login`、`/terms`、`/privacy`、`/legal` のパブリックページでは `null` を返し `AppHeader` を非表示にする
- それ以外のページでは `AppHeader` をそのまま表示する

### `src/app/layout.tsx`（変更）

- `AppHeader` の直接利用を `ConditionalHeader` に差し替え
- セッションチェックのロジック自体は変更なし

## 動作確認

- [ ] ログイン済みで `/` にアクセス → `AppHeader` が表示されない（ページ内ヘッダーのみ）
- [ ] ログイン済みで `/dashboard` にアクセス → `AppHeader` が表示される
- [ ] ログイン済みで `/login`、`/terms`、`/privacy`、`/legal` にアクセス → `AppHeader` が表示されない
- [ ] 未ログインで任意ページにアクセス → `AppHeader` が表示されない（セッションなしのため）
