### PR TITLE
refactor(notify): ローカルのkindLabelsをKIND_LABELのインポートに統一する

### DIFF
--- a/src/features/notifications/notify.ts
+++ b/src/features/notifications/notify.ts
@@ -19,6 +19,7 @@ import { prisma } from "@/lib/prisma";
 import type { Prisma } from "@prisma/client";
 import { sendEmail } from "@/lib/mailer";
 import { isProUser } from "@/features/deadlines/gate";
+import { KIND_LABEL } from "@/features/deadlines/format";
 import { env } from "@/lib/env";
 
 /** Free プランの通知オフセット（分） */
@@ -68,13 +69,7 @@ export function buildNotificationHtml(params: {
     .replace(/\..*$/, "")
     .slice(0, 16); // "YYYY-MM-DD HH:MM"
 
-  const kindLabels: Record<string, string> = {
-    es: "ES",
-    briefing: "説明会",
-    interview: "面接",
-    other: "その他",
-  };
-  const kindLabel = kindLabels[kind] ?? kind;
+  const kindLabel = KIND_LABEL[kind] ?? kind;
 
   const subject = `【締切${label}前】${companyName}（${kindLabel}）`;
   const html = `


### PR DESCRIPTION
## 概要

`notify.ts` 内のローカル変数 `kindLabels` を削除し、`format.ts` に既存の `KIND_LABEL` をインポートして使用するよう統一する。

## 関連Issue

Closes #144

## 変更点

- `src/features/notifications/notify.ts`: `kindLabels` ローカル定義を削除し、`KIND_LABEL` を `@/features/deadlines/format` からインポート

## 動作確認

- `npx tsc --noEmit` — 型エラーなし
