### PR TITLE
refactor(auth): requireSession()ユーティリティを追加してセッション確認を共通化する

### DIFF
--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -1,13 +1,11 @@
 
-import { redirect } from "next/navigation";
-import { getSession } from "@/features/auth/session";
+import { requireSession } from "@/lib/auth";
 import { getUserPlan } from "@/features/deadlines/gate";
 import { UpgradeButton } from "./UpgradeButton";
 import { PortalButton } from "./PortalButton";
 
 export default async function BillingPage() {
-  const session = await getSession();
-  if (!session) redirect("/login");
+  const session = await requireSession();
 
   const plan = await getUserPlan(session.sub);
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,6 @@
 
-import { redirect } from "next/navigation";
 import Link from "next/link";
-import { getSession } from "@/features/auth/session";
+import { requireSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import DeadlineList, { type DeadlineItem } from "./DeadlineList";
 import { FREE_ITEM_LIMIT, isProUser } from "@/features/deadlines/gate";
@@ -15,11 +14,7 @@ import { getUrgencyLevel } from "@/features/deadlines/format";
  * - ログイン済 → Prisma で deadline_at 昇順取得し DeadlineList に渡す
  */
 export default async function DashboardPage() {
-  // 1. 認証確認（引数なし = Server Component 用パス）
-  const session = await getSession();
-  if (!session) {
-    redirect("/login");
-  }
+  const session = await requireSession();
 
   // 2. ダッシュボード表示の計測（重複は集計側で吸収する設計・エラーはキャッチ済みなのでawait可）
   await trackEvent({ name: "dashboard_viewed", userId: session.sub });

--- a/src/app/deadline/[id]/edit/page.tsx
+++ b/src/app/deadline/[id]/edit/page.tsx
@@ -1,5 +1,5 @@
-import { notFound, redirect } from "next/navigation";
-import { getSession } from "@/features/auth/session";
+import { notFound } from "next/navigation";
+import { requireSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import DeadlineEditForm from "./DeadlineEditForm";
 
@@ -24,10 +24,7 @@ function toJstDatetimeLocal(iso: string): string {
 }
 
 export default async function DeadlineEditPage({ params }: Props) {
-  const session = await getSession();
-  if (!session) {
-    redirect("/login");
-  }
+  const session = await requireSession();
 
   const { id } = await params;
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,9 @@
+import { redirect } from "next/navigation";
+import { getSession, type SessionPayload } from "@/features/auth/session";
+
+/** Server Component 用: 未認証なら /login へリダイレクト、認証済みなら session を返す */
+export async function requireSession(): Promise<SessionPayload> {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  return session;
+}


### PR DESCRIPTION
## 概要

Server Component での認証確認パターン（`getSession()` + `if (!session) redirect("/login")`）が各ページに重複していたため、`requireSession()` ユーティリティに共通化する。

## 関連Issue

Closes #145

## 変更点

- `src/lib/auth.ts`（新規）: `requireSession()` — 未認証なら `/login` へリダイレクト、認証済みなら `SessionPayload` を返す
- `src/app/dashboard/page.tsx`: `requireSession()` に置き換え
- `src/app/billing/page.tsx`: `requireSession()` に置き換え
- `src/app/deadline/[id]/edit/page.tsx`: `requireSession()` に置き換え

## 動作確認

- `npx tsc --noEmit` — 型エラーなし
