### PR TITLE
refactor(api): requireAuth()ユーティリティを追加してAPIルートの認証を共通化する

### DIFF
--- a/src/app/api/deadlines/[id]/route.ts
+++ b/src/app/api/deadlines/[id]/route.ts
@@ -29,7 +29,7 @@
 export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/features/auth/session";
+import { requireAuth } from "@/lib/api";
 import { prisma } from "@/lib/prisma";
 import { validateUpdateDeadline } from "@/features/deadlines/validate";
 
@@ -38,14 +38,9 @@ type RouteContext = { params: Promise<{ id: string }> };
 export async function PATCH(req: NextRequest, { params }: RouteContext) {
   try {
     // 1. 認証確認
-    const session = await getSession(req);
-    if (!session) {
-      return NextResponse.json(
-        { error: "ログインが必要です" },
-        { status: 401 },
-      );
-    }
-    const userId = session.sub;
+    const auth = await requireAuth(req);
+    if (!auth.ok) return auth.response;
+    const userId = auth.session.sub;
     const { id } = await params;
 
     // 2. バリデーション
@@ -104,14 +99,9 @@ export async function PATCH(req: NextRequest, { params }: RouteContext) {
 export async function DELETE(req: NextRequest, { params }: RouteContext) {
   try {
     // 1. 認証確認
-    const session = await getSession(req);
-    if (!session) {
-      return NextResponse.json(
-        { error: "ログインが必要です" },
-        { status: 401 },
-      );
-    }
-    const userId = session.sub;
+    const auth = await requireAuth(req);
+    if (!auth.ok) return auth.response;
+    const userId = auth.session.sub;
     const { id } = await params;
 
     // 2. ユーザースコープ確認

--- a/src/app/api/deadlines/route.ts
+++ b/src/app/api/deadlines/route.ts
@@ -37,7 +37,7 @@
 export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/features/auth/session";
+import { requireAuth } from "@/lib/api";
 import { prisma } from "@/lib/prisma";
 import { validateCreateDeadline } from "@/features/deadlines/validate";
 import { FREE_ITEM_LIMIT, isProUser } from "@/features/deadlines/gate";
@@ -46,14 +46,9 @@ import { trackEvent } from "@/features/analytics";
 export async function POST(req: NextRequest) {
   try {
     // 1. 認証確認
-    const session = await getSession(req);
-    if (!session) {
-      return NextResponse.json(
-        { error: "ログインが必要です" },
-        { status: 401 },
-      );
-    }
-    const userId = session.sub;
+    const auth = await requireAuth(req);
+    if (!auth.ok) return auth.response;
+    const userId = auth.session.sub;
 
     // 2. バリデーション
     const body = await req.json().catch(() => ({}));
@@ -110,14 +105,9 @@ export async function POST(req: NextRequest) {
 export async function GET(req: NextRequest) {
   try {
     // 1. 認証確認
-    const session = await getSession(req);
-    if (!session) {
-      return NextResponse.json(
-        { error: "ログインが必要です" },
-        { status: 401 },
-      );
-    }
-    const userId = session.sub;
+    const auth = await requireAuth(req);
+    if (!auth.ok) return auth.response;
+    const userId = auth.session.sub;
 
     // 2. ログインユーザーのアイテムのみ取得（deadline_at 昇順）
     const items = await prisma.deadlineItem.findMany({

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -21,7 +21,7 @@
 export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/features/auth/session";
+import { requireAuth } from "@/lib/api";
 import { getStripe } from "@/lib/stripe";
 import { prisma } from "@/lib/prisma";
 import { env } from "@/lib/env";
@@ -37,15 +37,10 @@ export function GET() {
 export async function POST(req: NextRequest) {
   try {
     // 1. 認証確認
-    const session = await getSession(req);
-    if (!session) {
-      return NextResponse.json(
-        { error: "ログインが必要です" },
-        { status: 401 },
-      );
-    }
-    const userId = session.sub;
-    const email = session.email;
+    const auth = await requireAuth(req);
+    if (!auth.ok) return auth.response;
+    const userId = auth.session.sub;
+    const email = auth.session.email;
 
     // 2. 環境変数取得
     const priceId = env.STRIPE_PRICE_ID;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession, type SessionPayload } from "@/features/auth/session";
+
+type AuthSuccess = { ok: true; session: SessionPayload };
+type AuthFailure = { ok: false; response: NextResponse };
+
+/** Route Handler 用: 未認証なら 401 レスポンスを返す discriminated union */
+export async function requireAuth(
+  req: NextRequest,
+): Promise<AuthSuccess | AuthFailure> {
+  const session = await getSession(req);
+  if (!session) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "ログインが必要です" }, { status: 401 }),
+    };
+  }
+  return { ok: true, session };
+}


### PR DESCRIPTION
## 概要

Route Handler での認証確認パターン（`getSession(req)` + `if (!session) return 401`）が5ハンドラーに重複していたため、`requireAuth()` ユーティリティに共通化する。

## 関連Issue

Closes #147

## 変更点

- `src/lib/api.ts`（新規）: `requireAuth()` — 未認証なら `{ ok: false, response: 401 }`, 認証済みなら `{ ok: true, session }` を返す discriminated union
- `src/app/api/deadlines/route.ts`: POST/GET ハンドラーを `requireAuth()` に置き換え
- `src/app/api/deadlines/[id]/route.ts`: PATCH/DELETE ハンドラーを `requireAuth()` に置き換え
- `src/app/api/stripe/checkout/route.ts`: POST ハンドラーを `requireAuth()` に置き換え

## 動作確認

- `npx tsc --noEmit` — 型エラーなし
