### PR TITLE
design(header): グローバルヘッダー・フッターをブランドカラーで刷新する

### DIFF
--- a/src/app/_components/AppHeader.tsx
+++ b/src/app/_components/AppHeader.tsx
@@ -2,6 +2,8 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { motion } from "framer-motion";
+import { fadeUp } from "@/lib/motion";
 
 interface AppHeaderProps {
   email: string;
@@ -17,23 +19,34 @@ export function AppHeader({ email }: AppHeaderProps) {
   }
 
   return (
-    <header className="border-b border-slate-100">
-      <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
-        <Link href="/dashboard" className="text-lg font-bold text-slate-900">
+    <motion.header
+      className="border-b border-indigo-100 bg-white"
+      initial={fadeUp.initial}
+      animate={fadeUp.animate}
+      transition={fadeUp.transition}
+    >
+      <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-3">
+        <Link
+          href="/dashboard"
+          className="text-lg font-black text-indigo-600 hover:text-indigo-700 transition-colors"
+        >
           〆トラ
         </Link>
-        <div className="flex items-center gap-4">
-          <span className="text-sm text-slate-600" title={email}>
+        <div className="flex items-center gap-3">
+          <span
+            className="text-sm text-slate-600 hidden sm:block"
+            title={email}
+          >
             {displayEmail}
           </span>
           <button
             onClick={handleLogout}
-            className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+            className="min-h-[44px] min-w-[44px] rounded-md border border-indigo-200 px-4 py-2 text-sm font-medium text-indigo-600 hover:bg-indigo-50 hover:border-indigo-300 transition-colors"
           >
             ログアウト
           </button>
         </div>
       </div>
-    </header>
+    </motion.header>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,12 +20,12 @@ export default async function RootLayout({
 
   return (
     <html lang="ja">
-      <body className="flex min-h-screen flex-col">
+      <body className="font-sans flex min-h-screen flex-col">
         {/* GTM スクリプト: body 先頭に配置（noscript フォールバック含む） */}
         <GtmScript />
         {session && <ConditionalHeader email={session.email} />}
         <div className="flex-1">{children}</div>
-        <footer className="border-t border-slate-200 bg-slate-50 py-4 text-center text-xs text-slate-500">
+        <footer className="border-t border-indigo-100 bg-gray-50 py-4 text-center text-xs text-slate-500">
           <nav className="space-x-4">
             <Link href="/terms" className="hover:underline">
               利用規約


### PR DESCRIPTION
## 概要

Issue #159 で整備したデザインシステム基盤（`design/brand-foundation`）を元に、グローバルヘッダーとフッターをブランドカラー（Indigo）で統一します。

Closes #161

## 変更点

### `src/app/_components/AppHeader.tsx`
- ロゴ「〆トラ」を `font-black text-indigo-600` に変更
- ヘッダーのボーダーを `border-indigo-100` に変更（Indigo アクセント）
- ログアウトボタンのタッチターゲットを `min-h-[44px] min-w-[44px]` で最低44px相当に改善
- ボタン・ロゴのスタイルを Indigo 系カラーに統一（`text-indigo-600`・`border-indigo-200`・`hover:bg-indigo-50`）
- `framer-motion` の `fadeUp` アニメーションを初回マウント時に適用

### `src/app/layout.tsx`
- `body` に `font-sans` クラスを追加（Inter + Noto Sans JP が tailwind.config に設定済み）
- フッターのボーダー・背景を `border-indigo-100 bg-gray-50` に変更（ブランドカラーと統一）

## 動作確認

- [ ] `npx tsc --noEmit` でエラーなし（確認済み）
- [ ] ヘッダーのロゴが indigo-600 で太字表示される
- [ ] ログアウトボタンのタッチターゲットが十分な大きさになっている
- [ ] ヘッダー初回表示時に fadeUp アニメーションが再生される
- [ ] `prefers-reduced-motion` 設定時にアニメーションが抑制される（globals.css で設定済み）
- [ ] フッターが indigo-100 ボーダー・gray-50 背景で表示される
- [ ] body の font-sans クラスが適用されている
