### PR TITLE
design(form): 締切フォームをブランドカラー・アニメーションで刷新する

### DIFF
--- a/src/app/deadline/[id]/edit/page.tsx
+++ b/src/app/deadline/[id]/edit/page.tsx
@@ -48,7 +48,7 @@ export default async function DeadlineEditPage({ params }: Props) {
 
   return (
     <main className="mx-auto max-w-2xl p-6">
-      <h1 className="text-xl font-semibold">締切の編集</h1>
+      <h1 className="text-2xl font-bold">締切の編集</h1>
       <p className="mt-1 text-sm text-slate-500">
         <span className="text-red-500">*</span> は必須項目です
       </p>

--- a/src/app/deadline/new/DeadlineForm.tsx
+++ b/src/app/deadline/new/DeadlineForm.tsx
@@ -3,7 +3,9 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { AnimatePresence, motion } from "framer-motion";
 import { KIND_LABEL } from "@/features/deadlines/format";
+import { scaleIn } from "@/lib/motion";
 
 type FieldErrors = Record<string, string>;
 type Status = "idle" | "submitting" | "error" | "limit_exceeded";
@@ -126,7 +128,7 @@ export default function DeadlineForm(props: Props) {
   const isLimitExceeded = status === "limit_exceeded";
 
   return (
-    <form onSubmit={handleSubmit} noValidate className="mt-6 space-y-6">
+    <form onSubmit={handleSubmit} noValidate className="mt-8 space-y-5">
       {/* Free 枠上限エラー（create モードのみ） */}
       {isLimitExceeded && (
         <div
@@ -174,17 +176,19 @@ export default function DeadlineForm(props: Props) {
           placeholder="例: 株式会社テクノロジー"
           maxLength={100}
           disabled={isSubmitting}
-          className={`mt-1 w-full rounded-lg border px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 ${
+          className={`mt-1 w-full rounded-lg border px-3 py-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 ${
             fieldErrors.company_name
               ? "border-red-400 bg-red-50"
               : "border-slate-300 bg-white"
           }`}
         />
-        {fieldErrors.company_name && (
-          <p className="mt-1 text-xs text-red-600" role="alert">
-            {fieldErrors.company_name}
-          </p>
-        )}
+        <AnimatePresence>
+          {fieldErrors.company_name && (
+            <motion.p {...scaleIn} role="alert" className="mt-1 text-xs text-red-600">
+              {fieldErrors.company_name}
+            </motion.p>
+          )}
+        </AnimatePresence>
       </div>
 
       {/* 種別 */}
@@ -201,7 +205,7 @@ export default function DeadlineForm(props: Props) {
           value={kind}
           onChange={(e) => setKind(e.target.value)}
           disabled={isSubmitting}
-          className={`mt-1 w-full rounded-lg border px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 ${
+          className={`mt-1 w-full rounded-lg border px-3 py-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 ${
             fieldErrors.kind
               ? "border-red-400 bg-red-50"
               : "border-slate-300 bg-white"
@@ -214,11 +218,13 @@ export default function DeadlineForm(props: Props) {
             </option>
           ))}
         </select>
-        {fieldErrors.kind && (
-          <p className="mt-1 text-xs text-red-600" role="alert">
-            {fieldErrors.kind}
-          </p>
-        )}
+        <AnimatePresence>
+          {fieldErrors.kind && (
+            <motion.p {...scaleIn} role="alert" className="mt-1 text-xs text-red-600">
+              {fieldErrors.kind}
+            </motion.p>
+          )}
+        </AnimatePresence>
       </div>
 
       {/* 締切日時 */}
@@ -236,17 +242,19 @@ export default function DeadlineForm(props: Props) {
           value={deadlineAt}
           onChange={(e) => setDeadlineAt(e.target.value)}
           disabled={isSubmitting}
-          className={`mt-1 w-full rounded-lg border px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 ${
+          className={`mt-1 w-full rounded-lg border px-3 py-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 ${
             fieldErrors.deadline_at
               ? "border-red-400 bg-red-50"
               : "border-slate-300 bg-white"
           }`}
         />
-        {fieldErrors.deadline_at && (
-          <p className="mt-1 text-xs text-red-600" role="alert">
-            {fieldErrors.deadline_at}
-          </p>
-        )}
+        <AnimatePresence>
+          {fieldErrors.deadline_at && (
+            <motion.p {...scaleIn} role="alert" className="mt-1 text-xs text-red-600">
+              {fieldErrors.deadline_at}
+            </motion.p>
+          )}
+        </AnimatePresence>
       </div>
 
       {/* リンク（任意） */}
@@ -266,17 +274,19 @@ export default function DeadlineForm(props: Props) {
           placeholder="https://example.com/job"
           maxLength={2048}
           disabled={isSubmitting}
-          className={`mt-1 w-full rounded-lg border px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 ${
+          className={`mt-1 w-full rounded-lg border px-3 py-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 ${
             fieldErrors.link
               ? "border-red-400 bg-red-50"
               : "border-slate-300 bg-white"
           }`}
         />
-        {fieldErrors.link && (
-          <p className="mt-1 text-xs text-red-600" role="alert">
-            {fieldErrors.link}
-          </p>
-        )}
+        <AnimatePresence>
+          {fieldErrors.link && (
+            <motion.p {...scaleIn} role="alert" className="mt-1 text-xs text-red-600">
+              {fieldErrors.link}
+            </motion.p>
+          )}
+        </AnimatePresence>
       </div>
 
       {/* メモ（任意） */}
@@ -296,17 +306,19 @@ export default function DeadlineForm(props: Props) {
           maxLength={1000}
           rows={3}
           disabled={isSubmitting}
-          className={`mt-1 w-full rounded-lg border px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 ${
+          className={`mt-1 w-full rounded-lg border px-3 py-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 ${
             fieldErrors.memo
               ? "border-red-400 bg-red-50"
               : "border-slate-300 bg-white"
           }`}
         />
-        {fieldErrors.memo && (
-          <p className="mt-1 text-xs text-red-600" role="alert">
-            {fieldErrors.memo}
-          </p>
-        )}
+        <AnimatePresence>
+          {fieldErrors.memo && (
+            <motion.p {...scaleIn} role="alert" className="mt-1 text-xs text-red-600">
+              {fieldErrors.memo}
+            </motion.p>
+          )}
+        </AnimatePresence>
       </div>
 
       {/* 送信ボタン */}
@@ -314,7 +326,7 @@ export default function DeadlineForm(props: Props) {
         <button
           type="submit"
           disabled={isSubmitting || isLimitExceeded}
-          className="rounded-lg bg-blue-600 px-6 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="rounded-lg bg-indigo-600 px-6 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {isSubmitting
             ? "保存中..."

--- a/src/app/deadline/new/page.tsx
+++ b/src/app/deadline/new/page.tsx
@@ -3,7 +3,7 @@ import DeadlineForm from "./DeadlineForm";
 export default function NewDeadlinePage() {
   return (
     <main className="mx-auto max-w-2xl p-6">
-      <h1 className="text-xl font-semibold">締切の新規作成</h1>
+      <h1 className="text-2xl font-bold">締切の新規作成</h1>
       <p className="mt-1 text-sm text-slate-500">
         <span className="text-red-500">*</span> は必須項目です
       </p>

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,0 +1,15 @@
+export const fadeUp = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0 },
+  transition: { duration: 0.4, ease: [0.25, 0.46, 0.45, 0.94] as const },
+};
+
+export const stagger = {
+  animate: { transition: { staggerChildren: 0.06 } },
+};
+
+export const scaleIn = {
+  initial: { opacity: 0, scale: 0.95 },
+  animate: { opacity: 1, scale: 1 },
+  transition: { duration: 0.2 },
+};


### PR DESCRIPTION
## 概要

締切フォーム（新規作成・編集）をデザインシステム（Issue #159 / `design/brand-foundation`）に合わせてブランドカラーとアニメーションで刷新します。

Closes #163

## 変更点

- **ブランドカラー適用**: プライマリボタンを `bg-blue-600` から `bg-indigo-600 hover:bg-indigo-700` に変更
- **フォーカスリング統一**: 全入力フィールドのフォーカスリングを `ring-blue-500` から `ring-indigo-500` に変更
- **エラーアニメーション**: 全フィールドのエラーメッセージに `AnimatePresence` + `scaleIn` で出現アニメーションを追加
- **タッチターゲット改善**: 全入力フィールドの高さを `py-2` から `py-3` に拡大
- **タイポグラフィスケール調整**: new/edit 両ページのタイトルを `text-xl font-semibold` から `text-2xl font-bold` に変更
- **フォームコンテナ調整**: `mt-6 space-y-6` から `mt-8 space-y-5` に変更
- **motion.ts を追加**: `design/brand-foundation` で定義されたアニメーション定数ファイルを本ブランチにも追加

## 動作確認

- [ ] `/deadline/new` でフォームが正しく表示されること
- [ ] `/deadline/[id]/edit` でフォームが正しく表示されること
- [ ] 必須フィールドを空のまま送信した際にエラーメッセージが `scaleIn` アニメーションで表示されること
- [ ] ボタン・フォーカスリングがインディゴカラーで表示されること
- [ ] `npx tsc --noEmit` が通ること
