### PR TITLE
design(dashboard): 緊急度カラー更新とリスト入場アニメーション追加

### DIFF
--- a/src/app/_components/AppHeader.tsx
+++ b/src/app/_components/AppHeader.tsx
@@ -2,6 +2,8 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { motion } from "framer-motion";
+import { fadeUp } from "@/lib/motion";
 
 interface AppHeaderProps {
   email: string;
@@ -17,23 +19,34 @@ export function AppHeader({ email }: AppHeaderProps) {
   }
 
   return (
-    <header className="border-b border-slate-100">
-      <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
-        <Link href="/dashboard" className="text-lg font-bold text-slate-900">
+    <motion.header
+      className="border-b border-indigo-100 bg-white"
+      initial={fadeUp.initial}
+      animate={fadeUp.animate}
+      transition={fadeUp.transition}
+    >
+      <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-3">
+        <Link
+          href="/dashboard"
+          className="text-lg font-black text-indigo-600 hover:text-indigo-700 transition-colors"
+        >
           〆トラ
         </Link>
-        <div className="flex items-center gap-4">
-          <span className="text-sm text-slate-600" title={email}>
+        <div className="flex items-center gap-3">
+          <span
+            className="text-sm text-slate-600 hidden sm:block"
+            title={email}
+          >
             {displayEmail}
           </span>
           <button
             onClick={handleLogout}
-            className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+            className="min-h-[44px] min-w-[44px] rounded-md border border-indigo-200 px-4 py-2 text-sm font-medium text-indigo-600 hover:bg-indigo-50 hover:border-indigo-300 transition-colors"
           >
             ログアウト
           </button>
         </div>
       </div>
-    </header>
+    </motion.header>
   );
 }

--- a/src/app/dashboard/DeadlineList.tsx
+++ b/src/app/dashboard/DeadlineList.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { motion, AnimatePresence } from "framer-motion";
 import {
   formatDeadline,
   getUrgencyLevel,
@@ -138,7 +139,15 @@ export default function DeadlineList({ initialItems }: Props) {
         </div>
       )}
 
-      <ul className="space-y-3">
+      <motion.ul
+        className="space-y-3"
+        initial="hidden"
+        animate="visible"
+        variants={{
+          hidden: {},
+          visible: { transition: { staggerChildren: 0.07 } },
+        }}
+      >
         {items.map((item) => {
           const urgency = getUrgencyLevel(item.deadlineAt);
           const isUpdating = updatingId === item.id;
@@ -146,8 +155,13 @@ export default function DeadlineList({ initialItems }: Props) {
           const isConfirming = confirmDeleteId === item.id;
 
           return (
-            <li
+            <motion.li
               key={item.id}
+              variants={{
+                hidden: { opacity: 0, y: 12 },
+                visible: { opacity: 1, y: 0, transition: { duration: 0.25, ease: "easeOut" } },
+              }}
+              layout
               className={`rounded-lg px-4 py-3 shadow-sm transition-opacity ${URGENCY_CLASS[urgency]} ${isUpdating || isDeleting ? "opacity-60" : ""} ${isConfirming ? "ring-1 ring-red-300" : ""}`}
             >
               <div className="flex items-start justify-between gap-3">
@@ -254,10 +268,10 @@ export default function DeadlineList({ initialItems }: Props) {
                 )}
                 </div>
               </div>
-            </li>
+            </motion.li>
           );
         })}
-      </ul>
+      </motion.ul>
     </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,12 +20,12 @@ export default async function RootLayout({
 
   return (
     <html lang="ja">
-      <body className="flex min-h-screen flex-col">
+      <body className="font-sans flex min-h-screen flex-col">
         {/* GTM スクリプト: body 先頭に配置（noscript フォールバック含む） */}
         <GtmScript />
         {session && <ConditionalHeader email={session.email} />}
         <div className="flex-1">{children}</div>
-        <footer className="border-t border-slate-200 bg-slate-50 py-4 text-center text-xs text-slate-500">
+        <footer className="border-t border-indigo-100 bg-gray-50 py-4 text-center text-xs text-slate-500">
           <nav className="space-x-4">
             <Link href="/terms" className="hover:underline">
               利用規約

--- a/src/features/deadlines/format.ts
+++ b/src/features/deadlines/format.ts
@@ -53,9 +53,9 @@ export function getUrgencyLevel(
 
 export const URGENCY_CLASS: Record<UrgencyLevel, string> = {
   overdue: "border-l-4 border-red-500 bg-red-50",
-  today: "border-l-4 border-red-400 bg-red-50",
+  today: "border-l-4 border-orange-400 bg-orange-50",
   soon: "border-l-4 border-yellow-400 bg-yellow-50",
-  normal: "border-l-4 border-slate-200 bg-white",
+  normal: "border-l-4 border-indigo-200 bg-white",
 };
 
 export const KIND_LABEL: Record<string, string> = {
@@ -74,7 +74,7 @@ export const STATUS_LABEL: Record<string, string> = {
 
 export const STATUS_COLOR: Record<string, string> = {
   todo: "bg-slate-100 text-slate-600",
-  submitted: "bg-blue-100 text-blue-700",
+  submitted: "bg-indigo-100 text-indigo-700",
   done: "bg-green-100 text-green-700",
   canceled: "bg-slate-100 text-slate-400",
 };


### PR DESCRIPTION
## 概要

ダッシュボードの締切リストにブランドカラー統合とアニメーションを追加しました。

## 変更内容

- **緊急度カラー更新** (`format.ts`)
  - `today`: `border-red-400 / bg-red-50` → `border-orange-400 / bg-orange-50`（overdue の赤と視覚的に差別化）
  - `normal`: `border-slate-200` → `border-indigo-200`（ブランドカラーへ統合）
  - `submitted` ステータス: `bg-blue-100 text-blue-700` → `bg-indigo-100 text-indigo-700`（ブランドカラーへ統合）

- **入場アニメーション追加** (`DeadlineList.tsx`)
  - `ul` → `motion.ul`、`li` → `motion.li` に変更
  - stagger 70ms + fadeUp（y: 12→0、250ms easeOut）で順番に浮かび上がる演出
  - `layout` prop で楽観的更新時の並び替えもスムーズに

## テスト確認

- `npx tsc --noEmit`: エラーなし
- `npm test`: 107 tests passed (12 test files)