### PR TITLE
design(lp): LPをブランドアイデンティティ×スクロールアニメーションで全面刷新する

### DIFF
--- a/src/app/_components/lp/BenefitSection.tsx
+++ b/src/app/_components/lp/BenefitSection.tsx
@@ -1,45 +1,45 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { fadeUp } from "@/lib/motion";
 import { LP_CONTENT } from "./content";
 
 /**
- * BenefitSection — 利用後の変化を具体化するセクション（ダーク背景）
+ * BenefitSection — 利用後の変化を具体化するセクション
  */
 export function BenefitSection() {
   const { benefit } = LP_CONTENT;
 
   return (
-    <section className="py-20" style={{ backgroundColor: "#f7f7f7" }}>
+    <section className="bg-gray-50 py-20">
       <div className="mx-auto max-w-5xl px-6">
-        <h2
-          className="text-center text-3xl font-bold"
-          style={{
-            color: "#222222",
-            lineHeight: 1.2,
-            letterSpacing: "-0.02em",
-          }}
+        <motion.h2
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={fadeUp.transition}
+          className="text-center text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl"
         >
           {benefit.heading}
-        </h2>
+        </motion.h2>
         <ul className="mx-auto mt-10 max-w-md space-y-4">
-          {benefit.items.map((item) => (
-            <li
+          {benefit.items.map((item, i) => (
+            <motion.li
               key={item}
-              className="flex items-center gap-3 rounded-[14px] border p-5 text-base"
-              style={{
-                color: "#222222",
-                backgroundColor: "#ffffff",
-                borderColor: "#dddddd",
-                fontWeight: 500,
-              }}
+              initial={fadeUp.initial}
+              whileInView={fadeUp.animate}
+              viewport={{ once: true, margin: "-80px" }}
+              transition={{ ...fadeUp.transition, delay: i * 0.06 }}
+              className="flex items-center gap-3 rounded-2xl border border-gray-200 bg-white p-5 text-base font-medium text-gray-900"
             >
               <span
-                className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-xs font-bold"
-                style={{ backgroundColor: "#ff385c", color: "#ffffff" }}
+                className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-indigo-600 text-xs font-bold text-white"
                 aria-hidden="true"
               >
                 ✓
               </span>
               {item}
-            </li>
+            </motion.li>
           ))}
         </ul>
       </div>

--- a/src/app/_components/lp/BetaCtaSection.tsx
+++ b/src/app/_components/lp/BetaCtaSection.tsx
@@ -1,41 +1,56 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { fadeUp } from "@/lib/motion";
 import { LP_CONTENT } from "./content";
 import { LeadCaptureDialog } from "./LeadCaptureDialog";
 
 /**
- * BetaCtaSection — 下部の登録導線セクション（ダーク背景）
+ * BetaCtaSection — 下部の登録導線セクション
  * CTA: 先行利用に登録する
  */
 export function BetaCtaSection() {
   const { betaCta } = LP_CONTENT;
 
   return (
-    <section
-      className="py-24 text-center"
-      style={{ backgroundColor: "#222222" }}
-    >
+    <section className="bg-indigo-600 py-24 text-center">
       <div className="mx-auto max-w-5xl px-6">
-        <h2
-          className="text-3xl font-bold sm:text-4xl"
-          style={{
-            color: "#ffffff",
-            lineHeight: 1.2,
-            letterSpacing: "-0.02em",
-          }}
+        <motion.h2
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={fadeUp.transition}
+          className="text-3xl font-bold tracking-tight text-white sm:text-4xl"
         >
           {betaCta.heading}
-        </h2>
-        <p
-          className="mx-auto mt-4 max-w-lg text-base leading-relaxed"
-          style={{ color: "#929292", fontWeight: 500 }}
+        </motion.h2>
+        <motion.p
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ ...fadeUp.transition, delay: 0.06 }}
+          className="mx-auto mt-4 max-w-lg text-base font-medium leading-relaxed text-indigo-100"
         >
           {betaCta.body}
-        </p>
-        <div className="mt-10">
+        </motion.p>
+        <motion.div
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ ...fadeUp.transition, delay: 0.12 }}
+          className="mt-10"
+        >
           <LeadCaptureDialog label={betaCta.ctaLabel} ctaLocation="bottom" dark />
-        </div>
-        <p className="mt-4 text-sm" style={{ color: "#6a6a6a" }}>
+        </motion.div>
+        <motion.p
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ ...fadeUp.transition, delay: 0.18 }}
+          className="mt-4 text-sm text-indigo-200"
+        >
           {betaCta.note}
-        </p>
+        </motion.p>
       </div>
     </section>
   );

--- a/src/app/_components/lp/DifferenceSection.tsx
+++ b/src/app/_components/lp/DifferenceSection.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { fadeUp } from "@/lib/motion";
 import { LP_CONTENT } from "./content";
 
 /**
@@ -7,49 +11,48 @@ export function DifferenceSection() {
   const { difference } = LP_CONTENT;
 
   return (
-    <section className="py-20" style={{ backgroundColor: "#ffffff" }}>
+    <section className="bg-white py-20">
       <div className="mx-auto max-w-5xl px-6 text-center">
-        <h2
-          className="text-3xl font-bold"
-          style={{
-            color: "#222222",
-            lineHeight: 1.2,
-            letterSpacing: "-0.02em",
-          }}
+        <motion.h2
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={fadeUp.transition}
+          className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl"
         >
           {difference.heading}
-        </h2>
-        <p
-          className="mx-auto mt-4 max-w-lg text-base leading-relaxed"
-          style={{ color: "#6a6a6a", fontWeight: 500 }}
+        </motion.h2>
+        <motion.p
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ ...fadeUp.transition, delay: 0.06 }}
+          className="mx-auto mt-4 max-w-lg text-base font-medium leading-relaxed text-gray-500"
         >
           {difference.body}
-        </p>
+        </motion.p>
         {/* 価値ループ */}
-        <div
+        <motion.div
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ ...fadeUp.transition, delay: 0.12 }}
           className="mt-10 flex flex-wrap items-center justify-center gap-2"
           aria-label="価値ループ"
         >
           {difference.loop.map((step, i) => (
             <div key={step} className="flex items-center gap-2">
-              <span
-                className="rounded-[20px] px-4 py-1.5 text-sm font-medium"
-                style={{
-                  backgroundColor: "#ffffff",
-                  border: "1px solid #dddddd",
-                  color: "#222222",
-                }}
-              >
+              <span className="rounded-full border border-gray-200 bg-white px-4 py-1.5 text-sm font-medium text-gray-900">
                 {step}
               </span>
               {i < difference.loop.length - 1 && (
-                <span style={{ color: "#ff385c", fontWeight: 600 }} aria-hidden="true">
+                <span className="font-semibold text-indigo-600" aria-hidden="true">
                   →
                 </span>
               )}
             </div>
           ))}
-        </div>
+        </motion.div>
       </div>
     </section>
   );

--- a/src/app/_components/lp/HeroSection.tsx
+++ b/src/app/_components/lp/HeroSection.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { fadeUp, stagger } from "@/lib/motion";
 import { LP_CONTENT } from "./content";
 import { LeadCaptureDialog } from "./LeadCaptureDialog";
 
@@ -10,28 +14,41 @@ export function HeroSection() {
 
   return (
     <section className="mx-auto max-w-5xl px-6 py-24 text-center">
-      <h1
-        className="mx-auto max-w-2xl text-4xl font-bold leading-tight sm:text-5xl"
-        style={{
-          color: "#222222",
-          lineHeight: 1.1,
-          letterSpacing: "-0.02em",
-        }}
+      <motion.div
+        initial="initial"
+        animate="animate"
+        variants={stagger}
+        className="flex flex-col items-center"
       >
-        {hero.heading}
-      </h1>
-      <p
-        className="mx-auto mt-6 max-w-xl text-base leading-relaxed"
-        style={{ color: "#6a6a6a", fontWeight: 500 }}
-      >
-        {hero.subCopy}
-      </p>
-      <div className="mt-10">
-        <LeadCaptureDialog label={hero.ctaLabel} ctaLocation="hero" />
-      </div>
-      <p className="mt-4 text-sm" style={{ color: "#6a6a6a" }}>
-        {hero.note}
-      </p>
+        <motion.h1
+          variants={fadeUp}
+          transition={fadeUp.transition}
+          className="mx-auto max-w-2xl text-5xl font-black tracking-tighter text-gray-900 sm:text-7xl"
+        >
+          {hero.heading}
+        </motion.h1>
+        <motion.p
+          variants={fadeUp}
+          transition={fadeUp.transition}
+          className="mx-auto mt-6 max-w-xl text-base font-medium leading-relaxed text-gray-500"
+        >
+          {hero.subCopy}
+        </motion.p>
+        <motion.div
+          variants={fadeUp}
+          transition={fadeUp.transition}
+          className="mt-10"
+        >
+          <LeadCaptureDialog label={hero.ctaLabel} ctaLocation="hero" />
+        </motion.div>
+        <motion.p
+          variants={fadeUp}
+          transition={fadeUp.transition}
+          className="mt-4 text-sm text-gray-500"
+        >
+          {hero.note}
+        </motion.p>
+      </motion.div>
     </section>
   );
 }

--- a/src/app/_components/lp/HowItWorksSection.tsx
+++ b/src/app/_components/lp/HowItWorksSection.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { fadeUp } from "@/lib/motion";
 import { LP_CONTENT } from "./content";
 
 /**
@@ -7,42 +11,37 @@ export function HowItWorksSection() {
   const { howItWorks } = LP_CONTENT;
 
   return (
-    <section className="py-20" style={{ backgroundColor: "#ffffff" }}>
+    <section className="bg-white py-20">
       <div className="mx-auto max-w-5xl px-6">
-        <h2
-          className="text-center text-3xl font-bold"
-          style={{
-            color: "#222222",
-            lineHeight: 1.2,
-            letterSpacing: "-0.02em",
-          }}
+        <motion.h2
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={fadeUp.transition}
+          className="text-center text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl"
         >
           {howItWorks.heading}
-        </h2>
+        </motion.h2>
         <div className="mx-auto mt-12 grid max-w-3xl grid-cols-1 gap-6 sm:grid-cols-3">
-          {howItWorks.steps.map(({ number, label }) => (
-            <div
+          {howItWorks.steps.map(({ number, label }, i) => (
+            <motion.div
               key={number}
-              className="rounded-[14px] p-6"
-              style={{
-                backgroundColor: "#ffffff",
-                border: "1px solid #dddddd",
-              }}
+              initial={fadeUp.initial}
+              whileInView={fadeUp.animate}
+              viewport={{ once: true, margin: "-80px" }}
+              transition={{ ...fadeUp.transition, delay: i * 0.06 }}
+              className="rounded-2xl border border-gray-200 bg-white p-6"
             >
               <div
-                className="mb-4 text-3xl font-bold"
-                style={{ color: "#ff385c" }}
+                className="mb-4 text-3xl font-bold text-indigo-600"
                 aria-label={`ステップ ${number}`}
               >
                 {number}
               </div>
-              <p
-                className="text-base leading-relaxed"
-                style={{ color: "#222222", fontWeight: 500 }}
-              >
+              <p className="text-base font-medium leading-relaxed text-gray-900">
                 {label}
               </p>
-            </div>
+            </motion.div>
           ))}
         </div>
       </div>

--- a/src/app/_components/lp/LandingPage.tsx
+++ b/src/app/_components/lp/LandingPage.tsx
@@ -11,22 +11,15 @@ import { LeadCaptureDialog } from "./LeadCaptureDialog";
 
 /**
  * LP全体レイアウトを束ねる Server Component
- * デザイン方針: docs/DESIGN.md 参照（パーチメント系カラー + テラコッタCTA）
+ * デザイン方針: docs/DESIGN_SYSTEM.md 参照（Indigoブランドカラー）
  */
 export function LandingPage() {
   const { hero } = LP_CONTENT;
 
   return (
-    // Canvas White (#ffffff) — Airbnb デザインシステム準拠
-    <div className="min-h-screen" style={{ backgroundColor: "#ffffff" }}>
+    <div className="min-h-screen bg-white">
       {/* ナビゲーション */}
-      <header
-        className="sticky top-0 z-10 border-b"
-        style={{
-          borderColor: "#dddddd",
-          backgroundColor: "#ffffff",
-        }}
-      >
+      <header className="sticky top-0 z-10 border-b border-gray-200 bg-white">
         <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
           <div className="flex items-center gap-2">
             <Image
@@ -36,10 +29,7 @@ export function LandingPage() {
               height={72}
               className="rounded-sm"
             />
-            <span
-              className="text-lg font-semibold"
-              style={{ color: "#222222" }}
-            >
+            <span className="text-lg font-semibold text-gray-900">
               〆トラ
             </span>
           </div>
@@ -59,10 +49,7 @@ export function LandingPage() {
       </main>
 
       {/* フッター */}
-      <footer
-        className="border-t py-8 text-center text-sm"
-        style={{ borderColor: "#dddddd", backgroundColor: "#f7f7f7", color: "#6a6a6a" }}
-      >
+      <footer className="border-t border-gray-200 bg-gray-50 py-8 text-center text-sm text-gray-500">
         © 2026 〆トラ
       </footer>
     </div>

--- a/src/app/_components/lp/ProblemSection.tsx
+++ b/src/app/_components/lp/ProblemSection.tsx
@@ -1,45 +1,45 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { fadeUp } from "@/lib/motion";
 import { LP_CONTENT } from "./content";
 
 /**
- * ProblemSection — 課題共感を作るセクション（ダーク背景）
+ * ProblemSection — 課題共感を作るセクション
  */
 export function ProblemSection() {
   const { problem } = LP_CONTENT;
 
   return (
-    <section className="py-20" style={{ backgroundColor: "#f7f7f7" }}>
+    <section className="bg-gray-50 py-20">
       <div className="mx-auto max-w-5xl px-6">
-        <h2
-          className="text-center text-3xl font-bold"
-          style={{
-            color: "#222222",
-            lineHeight: 1.2,
-            letterSpacing: "-0.02em",
-          }}
+        <motion.h2
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={fadeUp.transition}
+          className="text-center text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl"
         >
           {problem.heading}
-        </h2>
+        </motion.h2>
         <ul className="mx-auto mt-10 max-w-lg space-y-4">
-          {problem.items.map((item) => (
-            <li
+          {problem.items.map((item, i) => (
+            <motion.li
               key={item}
-              className="flex items-start gap-3 rounded-[14px] border p-5 text-base leading-relaxed"
-              style={{
-                color: "#222222",
-                backgroundColor: "#ffffff",
-                borderColor: "#dddddd",
-                fontWeight: 500,
-              }}
+              initial={fadeUp.initial}
+              whileInView={fadeUp.animate}
+              viewport={{ once: true, margin: "-80px" }}
+              transition={{ ...fadeUp.transition, delay: i * 0.06 }}
+              className="flex items-start gap-3 rounded-2xl border border-gray-200 bg-white p-5 text-base font-medium leading-relaxed text-gray-900"
             >
               <span
-                className="mt-0.5 flex-shrink-0 text-sm font-semibold"
-                style={{ color: "#ff385c" }}
+                className="mt-0.5 flex-shrink-0 text-sm font-semibold text-indigo-600"
                 aria-hidden="true"
               >
                 ✕
               </span>
               {item}
-            </li>
+            </motion.li>
           ))}
         </ul>
       </div>


### PR DESCRIPTION
## 概要

Issue #159 で整備されたデザインシステム基盤（`design/brand-foundation`）を活用し、LPを全面刷新しました。旧ブランドカラー（`#ff385c`）をIndigoカラーに統一し、framer-motionによるスクロール連動アニメーションを追加しています。

Closes #160

## 変更点

### HeroSection
- 見出しを `text-5xl sm:text-7xl font-black tracking-tighter` の大きなヘッドラインに変更
- `framer-motion` の `motion.div` + `fadeUp` + `stagger` でテキスト・CTAが順番に下から出現するアニメーションを追加
- インラインスタイルを全てTailwindクラスに変換

### ProblemSection / HowItWorksSection / BenefitSection / DifferenceSection
- スクロール連動アニメーション（`whileInView` + `fadeUp`）を追加
- 各セクション見出しを `text-3xl sm:text-4xl font-bold tracking-tight` に統一
- インラインスタイルを全てTailwindクラスに変換
- `#ff385c` をIndigoアクセント（`text-indigo-600`, `bg-indigo-600`）に置き換え

### BetaCtaSection
- ダーク背景を `bg-indigo-600` に変更してブランドカラーを強調
- テキストカラーを `text-white` / `text-indigo-100` / `text-indigo-200` に調整
- スクロール連動アニメーションを追加

### LandingPage
- インラインスタイルを全てTailwindクラスに変換（ヘッダー・フッター含む）

## 動作確認

- [ ] `npx tsc --noEmit` でエラーなし（確認済み）
- [ ] HeroSection でページ読み込み時にテキストが順番にフェードアップで表示される
- [ ] 各セクションをスクロールすると要素がフェードアップで出現する
- [ ] モバイル（sm: 以下）でも適切なレイアウトになっている
- [ ] CTAボタン（LeadCaptureDialog）が全箇所で機能する
