### PR TITLE
design(auth-billing): ログインページと課金ページをブランドデザインで刷新する

### DIFF
--- a/src/app/billing/PortalButton.tsx
+++ b/src/app/billing/PortalButton.tsx
@@ -40,7 +40,7 @@ export function PortalButton() {
         </p>
       )}
       <button
-        className="rounded border border-slate-300 bg-white px-6 py-3 font-semibold text-slate-700 transition hover:bg-slate-50 disabled:opacity-60"
+        className="rounded-xl border border-gray-300 bg-white px-6 py-3 font-semibold text-gray-700 transition hover:bg-gray-50 disabled:opacity-60"
         disabled={loading}
         onClick={handlePortal}
         type="button"

--- a/src/app/billing/UpgradeButton.tsx
+++ b/src/app/billing/UpgradeButton.tsx
@@ -38,7 +38,7 @@ export function UpgradeButton() {
         </p>
       )}
       <button
-        className="rounded bg-blue-600 px-6 py-3 font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60"
+        className="rounded-xl bg-indigo-600 px-8 py-3 font-semibold text-white transition hover:bg-indigo-700 disabled:opacity-60"
         disabled={loading}
         onClick={handleUpgrade}
         type="button"

--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -4,60 +4,65 @@ import { getUserPlan } from "@/features/deadlines/gate";
 import { UpgradeButton } from "./UpgradeButton";
 import { PortalButton } from "./PortalButton";
 
+const FEATURES = [
+  { label: "締切アイテム登録数", free: "最大 10 件", pro: "無制限" },
+  { label: "メール通知タイミング", free: "24時間前のみ", pro: "72h / 24h / 3h 前" },
+  { label: "ダッシュボード", free: "✅", pro: "✅" },
+];
+
 export default async function BillingPage() {
   const session = await requireSession();
-
   const plan = await getUserPlan(session.sub);
 
   return (
-    <main className="mx-auto max-w-2xl p-6">
+    <main className="mx-auto max-w-3xl p-6">
       <h1 className="text-2xl font-bold">プランとお支払い</h1>
 
       {plan === "pro" && (
-        <p className="mt-3 rounded bg-blue-50 px-4 py-2 text-sm text-blue-700">
+        <p className="mt-3 rounded-lg bg-indigo-50 px-4 py-2 text-sm text-indigo-700">
           ✅ 現在 <strong>Pro</strong> プランをご利用中です。
         </p>
       )}
 
-      {/* Free / Pro 比較テーブル */}
-      <div className="mt-6 overflow-hidden rounded-lg border border-slate-200">
-        <table className="w-full text-sm">
-          <thead className="bg-slate-50">
-            <tr>
-              <th className="px-4 py-3 text-left text-slate-600">機能</th>
-              <th className="px-4 py-3 text-center text-slate-600">Free</th>
-              <th className="px-4 py-3 text-center font-semibold text-blue-600">
-                Pro（980円/月）
-              </th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-slate-100">
-            <tr>
-              <td className="px-4 py-3 text-slate-700">締切アイテム登録数</td>
-              <td className="px-4 py-3 text-center text-slate-500">最大 10 件</td>
-              <td className="px-4 py-3 text-center font-medium text-blue-600">無制限</td>
-            </tr>
-            <tr>
-              <td className="px-4 py-3 text-slate-700">メール通知タイミング</td>
-              <td className="px-4 py-3 text-center text-slate-500">24時間前のみ</td>
-              <td className="px-4 py-3 text-center font-medium text-blue-600">
-                72h / 24h / 3h 前
-              </td>
-            </tr>
-            <tr>
-              <td className="px-4 py-3 text-slate-700">ダッシュボード</td>
-              <td className="px-4 py-3 text-center text-slate-500">✅</td>
-              <td className="px-4 py-3 text-center text-blue-600">✅</td>
-            </tr>
-          </tbody>
-        </table>
+      {/* Free / Pro カード比較 */}
+      <div className="mt-8 grid gap-4 sm:grid-cols-2">
+        {/* Free カード */}
+        <div className="rounded-2xl border border-gray-200 bg-white p-6">
+          <p className="text-xs font-semibold uppercase tracking-widest text-gray-400">Free</p>
+          <p className="mt-1 text-3xl font-black text-gray-900">¥0<span className="text-base font-normal text-gray-400">/月</span></p>
+          <ul className="mt-4 space-y-2">
+            {FEATURES.map((f) => (
+              <li key={f.label} className="flex justify-between text-sm">
+                <span className="text-gray-600">{f.label}</span>
+                <span className="font-medium text-gray-700">{f.free}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Pro カード */}
+        <div className="rounded-2xl border-2 border-indigo-500 bg-white p-6 shadow-lg shadow-indigo-100/50">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-widest text-indigo-600">Pro</p>
+            <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-semibold text-indigo-700">おすすめ</span>
+          </div>
+          <p className="mt-1 text-3xl font-black text-gray-900">¥980<span className="text-base font-normal text-gray-400">/月</span></p>
+          <ul className="mt-4 space-y-2">
+            {FEATURES.map((f) => (
+              <li key={f.label} className="flex justify-between text-sm">
+                <span className="text-gray-600">{f.label}</span>
+                <span className="font-semibold text-indigo-600">{f.pro}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
 
       {/* CTA */}
       <div className="mt-8">
         {plan === "pro" ? (
           <div className="space-y-3">
-            <p className="text-sm text-slate-500">
+            <p className="text-sm text-gray-500">
               解約・支払い方法の変更は Stripe 管理画面からおこなえます。
             </p>
             <PortalButton />

--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -90,7 +90,7 @@ export default function LoginForm() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
-              className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-3 text-sm outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500"
             />
           </div>
 
@@ -103,7 +103,7 @@ export default function LoginForm() {
           <button
             type="submit"
             disabled={status === "loading"}
-            className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+            className="w-full rounded-lg bg-indigo-600 px-4 py-3 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-60"
           >
             {status === "loading" ? "送信中…" : "マジックリンクを送信"}
           </button>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -7,12 +7,16 @@ export const metadata = {
 
 export default function LoginPage() {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-slate-50 px-4">
-      <div className="w-full max-w-sm rounded-xl border border-slate-200 bg-white p-8 shadow-sm">
-        <h1 className="text-xl font-semibold text-slate-900">
+    <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-sm rounded-2xl border border-gray-200 bg-white p-8 shadow-lg">
+        <div className="mb-6 text-center">
+          <p className="text-2xl font-black tracking-tight text-indigo-600">〆トラ</p>
+          <p className="mt-0.5 text-xs text-gray-400">就活の締切を、逃さない。</p>
+        </div>
+        <h1 className="text-lg font-bold text-gray-900">
           ログイン / サインアップ
         </h1>
-        <p className="mt-1 text-sm text-slate-500">
+        <p className="mt-1 text-sm text-gray-500">
           メールアドレスを入力するとログインリンクを送ります。
         </p>
         {/* useSearchParams を使う LoginForm は Suspense で囲む */}


### PR DESCRIPTION
## 概要

ログインページと課金ページを Shimetra ブランドデザインで刷新する。
ログインページにロゴとカードデザインを追加し、課金ページを Free/Pro 比較カードレイアウトに改変する。

## 関連Issue

Closes #164

## 変更点

- **login/page.tsx**: 「〆トラ」ロゴ（`font-black text-indigo-600`）をカード上部に追加。カードを `rounded-2xl shadow-lg` で浮き上がった印象に変更
- **login/LoginForm.tsx**: 送信ボタンを `bg-blue-600` → `bg-indigo-600 hover:bg-indigo-700` に変更。フォーカスリングを `ring-indigo-500` に統一。入力フィールドを `py-3` に拡大（タッチターゲット改善）
- **billing/page.tsx**: テーブル形式を廃止し、Free/Pro の2カラム比較カードレイアウトに刷新。Pro カードを `border-2 border-indigo-500 shadow-indigo-100/50` でハイライト。「おすすめ」バッジを追加
- **billing/UpgradeButton.tsx**: `bg-blue-600` → `bg-indigo-600`、`rounded` → `rounded-xl` でブランドカラーに統一
- **billing/PortalButton.tsx**: `slate` 系カラーを `gray` 系に統一

## 動作確認

- `npx tsc --noEmit` — 型エラーなし
