### PR TITLE
design(ui): UI/UXリデザイン全変更をmainに統合する

### DIFF
--- a/src/app/_components/AppHeader.tsx
+++ b/src/app/_components/AppHeader.tsx
@@ -2,6 +2,8 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { motion } from "framer-motion";
+import { fadeUp } from "@/lib/motion";
 
 interface AppHeaderProps {
   email: string;
@@ -17,23 +19,34 @@ export function AppHeader({ email }: AppHeaderProps) {
   }
 
   return (
-    <header className="border-b border-slate-100">
-      <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
-        <Link href="/dashboard" className="text-lg font-bold text-slate-900">
+    <motion.header
+      className="border-b border-indigo-100 bg-white"
+      initial={fadeUp.initial}
+      animate={fadeUp.animate}
+      transition={fadeUp.transition}
+    >
+      <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-3">
+        <Link
+          href="/dashboard"
+          className="text-lg font-black text-indigo-600 hover:text-indigo-700 transition-colors"
+        >
           〆トラ
         </Link>
-        <div className="flex items-center gap-4">
-          <span className="text-sm text-slate-600" title={email}>
+        <div className="flex items-center gap-3">
+          <span
+            className="text-sm text-slate-600 hidden sm:block"
+            title={email}
+          >
             {displayEmail}
           </span>
           <button
             onClick={handleLogout}
-            className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+            className="min-h-[44px] min-w-[44px] rounded-md border border-indigo-200 px-4 py-2 text-sm font-medium text-indigo-600 hover:bg-indigo-50 hover:border-indigo-300 transition-colors"
           >
             ログアウト
           </button>
         </div>
       </div>
-    </header>
+    </motion.header>
   );
 }

--- a/src/app/_components/lp/BenefitSection.tsx
+++ b/src/app/_components/lp/BenefitSection.tsx
@@ -1,45 +1,45 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { fadeUp } from "@/lib/motion";
 import { LP_CONTENT } from "./content";
 
 /**
- * BenefitSection — 利用後の変化を具体化するセクション（ダーク背景）
+ * BenefitSection — 利用後の変化を具体化するセクション
  */
 export function BenefitSection() {
   const { benefit } = LP_CONTENT;
 
   return (
-    <section className="py-20" style={{ backgroundColor: "#f7f7f7" }}>
+    <section className="bg-gray-50 py-20">
       <div className="mx-auto max-w-5xl px-6">
-        <h2
-          className="text-center text-3xl font-bold"
-          style={{
-            color: "#222222",
-            lineHeight: 1.2,
-            letterSpacing: "-0.02em",
-          }}
+        <motion.h2
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={fadeUp.transition}
+          className="text-center text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl"
         >
           {benefit.heading}
-        </h2>
+        </motion.h2>
         <ul className="mx-auto mt-10 max-w-md space-y-4">
-          {benefit.items.map((item) => (
-            <li
+          {benefit.items.map((item, i) => (
+            <motion.li
               key={item}
-              className="flex items-center gap-3 rounded-[14px] border p-5 text-base"
-              style={{
-                color: "#222222",
-                backgroundColor: "#ffffff",
-                borderColor: "#dddddd",
-                fontWeight: 500,
-              }}
+              initial={fadeUp.initial}
+              whileInView={fadeUp.animate}
+              viewport={{ once: true, margin: "-80px" }}
+              transition={{ ...fadeUp.transition, delay: i * 0.06 }}
+              className="flex items-center gap-3 rounded-2xl border border-gray-200 bg-white p-5 text-base font-medium text-gray-900"
             >
               <span
-                className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-xs font-bold"
-                style={{ backgroundColor: "#ff385c", color: "#ffffff" }}
+                className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-indigo-600 text-xs font-bold text-white"
                 aria-hidden="true"
               >
                 ✓
               </span>
               {item}
-            </li>
+            </motion.li>
           ))}
         </ul>
       </div>

--- a/src/app/_components/lp/BetaCtaSection.tsx
+++ b/src/app/_components/lp/BetaCtaSection.tsx
@@ -1,41 +1,56 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { fadeUp } from "@/lib/motion";
 import { LP_CONTENT } from "./content";
 import { LeadCaptureDialog } from "./LeadCaptureDialog";
 
 /**
- * BetaCtaSection — 下部の登録導線セクション（ダーク背景）
+ * BetaCtaSection — 下部の登録導線セクション
  * CTA: 先行利用に登録する
  */
 export function BetaCtaSection() {
   const { betaCta } = LP_CONTENT;
 
   return (
-    <section
-      className="py-24 text-center"
-      style={{ backgroundColor: "#222222" }}
-    >
+    <section className="bg-indigo-600 py-24 text-center">
       <div className="mx-auto max-w-5xl px-6">
-        <h2
-          className="text-3xl font-bold sm:text-4xl"
-          style={{
-            color: "#ffffff",
-            lineHeight: 1.2,
-            letterSpacing: "-0.02em",
-          }}
+        <motion.h2
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={fadeUp.transition}
+          className="text-3xl font-bold tracking-tight text-white sm:text-4xl"
         >
           {betaCta.heading}
-        </h2>
-        <p
-          className="mx-auto mt-4 max-w-lg text-base leading-relaxed"
-          style={{ color: "#929292", fontWeight: 500 }}
+        </motion.h2>
+        <motion.p
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ ...fadeUp.transition, delay: 0.06 }}
+          className="mx-auto mt-4 max-w-lg text-base font-medium leading-relaxed text-indigo-100"
         >
           {betaCta.body}
-        </p>
-        <div className="mt-10">
+        </motion.p>
+        <motion.div
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ ...fadeUp.transition, delay: 0.12 }}
+          className="mt-10"
+        >
           <LeadCaptureDialog label={betaCta.ctaLabel} ctaLocation="bottom" dark />
-        </div>
-        <p className="mt-4 text-sm" style={{ color: "#6a6a6a" }}>
+        </motion.div>
+        <motion.p
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ ...fadeUp.transition, delay: 0.18 }}
+          className="mt-4 text-sm text-indigo-200"
+        >
           {betaCta.note}
-        </p>
+        </motion.p>
       </div>
     </section>
   );

--- a/src/app/_components/lp/DifferenceSection.tsx
+++ b/src/app/_components/lp/DifferenceSection.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { fadeUp } from "@/lib/motion";
 import { LP_CONTENT } from "./content";
 
 /**
@@ -7,49 +11,48 @@ export function DifferenceSection() {
   const { difference } = LP_CONTENT;
 
   return (
-    <section className="py-20" style={{ backgroundColor: "#ffffff" }}>
+    <section className="bg-white py-20">
       <div className="mx-auto max-w-5xl px-6 text-center">
-        <h2
-          className="text-3xl font-bold"
-          style={{
-            color: "#222222",
-            lineHeight: 1.2,
-            letterSpacing: "-0.02em",
-          }}
+        <motion.h2
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={fadeUp.transition}
+          className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl"
         >
           {difference.heading}
-        </h2>
-        <p
-          className="mx-auto mt-4 max-w-lg text-base leading-relaxed"
-          style={{ color: "#6a6a6a", fontWeight: 500 }}
+        </motion.h2>
+        <motion.p
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ ...fadeUp.transition, delay: 0.06 }}
+          className="mx-auto mt-4 max-w-lg text-base font-medium leading-relaxed text-gray-500"
         >
           {difference.body}
-        </p>
+        </motion.p>
         {/* 価値ループ */}
-        <div
+        <motion.div
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ ...fadeUp.transition, delay: 0.12 }}
           className="mt-10 flex flex-wrap items-center justify-center gap-2"
           aria-label="価値ループ"
         >
           {difference.loop.map((step, i) => (
             <div key={step} className="flex items-center gap-2">
-              <span
-                className="rounded-[20px] px-4 py-1.5 text-sm font-medium"
-                style={{
-                  backgroundColor: "#ffffff",
-                  border: "1px solid #dddddd",
-                  color: "#222222",
-                }}
-              >
+              <span className="rounded-full border border-gray-200 bg-white px-4 py-1.5 text-sm font-medium text-gray-900">
                 {step}
               </span>
               {i < difference.loop.length - 1 && (
-                <span style={{ color: "#ff385c", fontWeight: 600 }} aria-hidden="true">
+                <span className="font-semibold text-indigo-600" aria-hidden="true">
                   →
                 </span>
               )}
             </div>
           ))}
-        </div>
+        </motion.div>
       </div>
     </section>
   );

--- a/src/app/_components/lp/HeroSection.tsx
+++ b/src/app/_components/lp/HeroSection.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { fadeUp, stagger } from "@/lib/motion";
 import { LP_CONTENT } from "./content";
 import { LeadCaptureDialog } from "./LeadCaptureDialog";
 
@@ -10,28 +14,41 @@ export function HeroSection() {
 
   return (
     <section className="mx-auto max-w-5xl px-6 py-24 text-center">
-      <h1
-        className="mx-auto max-w-2xl text-4xl font-bold leading-tight sm:text-5xl"
-        style={{
-          color: "#222222",
-          lineHeight: 1.1,
-          letterSpacing: "-0.02em",
-        }}
+      <motion.div
+        initial="initial"
+        animate="animate"
+        variants={stagger}
+        className="flex flex-col items-center"
       >
-        {hero.heading}
-      </h1>
-      <p
-        className="mx-auto mt-6 max-w-xl text-base leading-relaxed"
-        style={{ color: "#6a6a6a", fontWeight: 500 }}
-      >
-        {hero.subCopy}
-      </p>
-      <div className="mt-10">
-        <LeadCaptureDialog label={hero.ctaLabel} ctaLocation="hero" />
-      </div>
-      <p className="mt-4 text-sm" style={{ color: "#6a6a6a" }}>
-        {hero.note}
-      </p>
+        <motion.h1
+          variants={fadeUp}
+          transition={fadeUp.transition}
+          className="mx-auto max-w-2xl text-5xl font-black tracking-tighter text-gray-900 sm:text-7xl"
+        >
+          {hero.heading}
+        </motion.h1>
+        <motion.p
+          variants={fadeUp}
+          transition={fadeUp.transition}
+          className="mx-auto mt-6 max-w-xl text-base font-medium leading-relaxed text-gray-500"
+        >
+          {hero.subCopy}
+        </motion.p>
+        <motion.div
+          variants={fadeUp}
+          transition={fadeUp.transition}
+          className="mt-10"
+        >
+          <LeadCaptureDialog label={hero.ctaLabel} ctaLocation="hero" />
+        </motion.div>
+        <motion.p
+          variants={fadeUp}
+          transition={fadeUp.transition}
+          className="mt-4 text-sm text-gray-500"
+        >
+          {hero.note}
+        </motion.p>
+      </motion.div>
     </section>
   );
 }

--- a/src/app/_components/lp/HowItWorksSection.tsx
+++ b/src/app/_components/lp/HowItWorksSection.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { fadeUp } from "@/lib/motion";
 import { LP_CONTENT } from "./content";
 
 /**
@@ -7,42 +11,37 @@ export function HowItWorksSection() {
   const { howItWorks } = LP_CONTENT;
 
   return (
-    <section className="py-20" style={{ backgroundColor: "#ffffff" }}>
+    <section className="bg-white py-20">
       <div className="mx-auto max-w-5xl px-6">
-        <h2
-          className="text-center text-3xl font-bold"
-          style={{
-            color: "#222222",
-            lineHeight: 1.2,
-            letterSpacing: "-0.02em",
-          }}
+        <motion.h2
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={fadeUp.transition}
+          className="text-center text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl"
         >
           {howItWorks.heading}
-        </h2>
+        </motion.h2>
         <div className="mx-auto mt-12 grid max-w-3xl grid-cols-1 gap-6 sm:grid-cols-3">
-          {howItWorks.steps.map(({ number, label }) => (
-            <div
+          {howItWorks.steps.map(({ number, label }, i) => (
+            <motion.div
               key={number}
-              className="rounded-[14px] p-6"
-              style={{
-                backgroundColor: "#ffffff",
-                border: "1px solid #dddddd",
-              }}
+              initial={fadeUp.initial}
+              whileInView={fadeUp.animate}
+              viewport={{ once: true, margin: "-80px" }}
+              transition={{ ...fadeUp.transition, delay: i * 0.06 }}
+              className="rounded-2xl border border-gray-200 bg-white p-6"
             >
               <div
-                className="mb-4 text-3xl font-bold"
-                style={{ color: "#ff385c" }}
+                className="mb-4 text-3xl font-bold text-indigo-600"
                 aria-label={`ステップ ${number}`}
               >
                 {number}
               </div>
-              <p
-                className="text-base leading-relaxed"
-                style={{ color: "#222222", fontWeight: 500 }}
-              >
+              <p className="text-base font-medium leading-relaxed text-gray-900">
                 {label}
               </p>
-            </div>
+            </motion.div>
           ))}
         </div>
       </div>

--- a/src/app/_components/lp/LandingPage.tsx
+++ b/src/app/_components/lp/LandingPage.tsx
@@ -11,22 +11,15 @@ import { LeadCaptureDialog } from "./LeadCaptureDialog";
 
 /**
  * LP全体レイアウトを束ねる Server Component
- * デザイン方針: docs/DESIGN.md 参照（パーチメント系カラー + テラコッタCTA）
+ * デザイン方針: docs/DESIGN_SYSTEM.md 参照（Indigoブランドカラー）
  */
 export function LandingPage() {
   const { hero } = LP_CONTENT;
 
   return (
-    // Canvas White (#ffffff) — Airbnb デザインシステム準拠
-    <div className="min-h-screen" style={{ backgroundColor: "#ffffff" }}>
+    <div className="min-h-screen bg-white">
       {/* ナビゲーション */}
-      <header
-        className="sticky top-0 z-10 border-b"
-        style={{
-          borderColor: "#dddddd",
-          backgroundColor: "#ffffff",
-        }}
-      >
+      <header className="sticky top-0 z-10 border-b border-gray-200 bg-white">
         <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
           <div className="flex items-center gap-2">
             <Image
@@ -36,10 +29,7 @@ export function LandingPage() {
               height={72}
               className="rounded-sm"
             />
-            <span
-              className="text-lg font-semibold"
-              style={{ color: "#222222" }}
-            >
+            <span className="text-lg font-semibold text-gray-900">
               〆トラ
             </span>
           </div>
@@ -59,10 +49,7 @@ export function LandingPage() {
       </main>
 
       {/* フッター */}
-      <footer
-        className="border-t py-8 text-center text-sm"
-        style={{ borderColor: "#dddddd", backgroundColor: "#f7f7f7", color: "#6a6a6a" }}
-      >
+      <footer className="border-t border-gray-200 bg-gray-50 py-8 text-center text-sm text-gray-500">
         © 2026 〆トラ
       </footer>
     </div>

--- a/src/app/_components/lp/ProblemSection.tsx
+++ b/src/app/_components/lp/ProblemSection.tsx
@@ -1,45 +1,45 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { fadeUp } from "@/lib/motion";
 import { LP_CONTENT } from "./content";
 
 /**
- * ProblemSection — 課題共感を作るセクション（ダーク背景）
+ * ProblemSection — 課題共感を作るセクション
  */
 export function ProblemSection() {
   const { problem } = LP_CONTENT;
 
   return (
-    <section className="py-20" style={{ backgroundColor: "#f7f7f7" }}>
+    <section className="bg-gray-50 py-20">
       <div className="mx-auto max-w-5xl px-6">
-        <h2
-          className="text-center text-3xl font-bold"
-          style={{
-            color: "#222222",
-            lineHeight: 1.2,
-            letterSpacing: "-0.02em",
-          }}
+        <motion.h2
+          initial={fadeUp.initial}
+          whileInView={fadeUp.animate}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={fadeUp.transition}
+          className="text-center text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl"
         >
           {problem.heading}
-        </h2>
+        </motion.h2>
         <ul className="mx-auto mt-10 max-w-lg space-y-4">
-          {problem.items.map((item) => (
-            <li
+          {problem.items.map((item, i) => (
+            <motion.li
               key={item}
-              className="flex items-start gap-3 rounded-[14px] border p-5 text-base leading-relaxed"
-              style={{
-                color: "#222222",
-                backgroundColor: "#ffffff",
-                borderColor: "#dddddd",
-                fontWeight: 500,
-              }}
+              initial={fadeUp.initial}
+              whileInView={fadeUp.animate}
+              viewport={{ once: true, margin: "-80px" }}
+              transition={{ ...fadeUp.transition, delay: i * 0.06 }}
+              className="flex items-start gap-3 rounded-2xl border border-gray-200 bg-white p-5 text-base font-medium leading-relaxed text-gray-900"
             >
               <span
-                className="mt-0.5 flex-shrink-0 text-sm font-semibold"
-                style={{ color: "#ff385c" }}
+                className="mt-0.5 flex-shrink-0 text-sm font-semibold text-indigo-600"
                 aria-hidden="true"
               >
                 ✕
               </span>
               {item}
-            </li>
+            </motion.li>
           ))}
         </ul>
       </div>

--- a/src/app/billing/PortalButton.tsx
+++ b/src/app/billing/PortalButton.tsx
@@ -40,7 +40,7 @@ export function PortalButton() {
         </p>
       )}
       <button
-        className="rounded border border-slate-300 bg-white px-6 py-3 font-semibold text-slate-700 transition hover:bg-slate-50 disabled:opacity-60"
+        className="rounded-xl border border-gray-300 bg-white px-6 py-3 font-semibold text-gray-700 transition hover:bg-gray-50 disabled:opacity-60"
         disabled={loading}
         onClick={handlePortal}
         type="button"

--- a/src/app/billing/UpgradeButton.tsx
+++ b/src/app/billing/UpgradeButton.tsx
@@ -38,7 +38,7 @@ export function UpgradeButton() {
         </p>
       )}
       <button
-        className="rounded bg-blue-600 px-6 py-3 font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60"
+        className="rounded-xl bg-indigo-600 px-8 py-3 font-semibold text-white transition hover:bg-indigo-700 disabled:opacity-60"
         disabled={loading}
         onClick={handleUpgrade}
         type="button"

--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -4,60 +4,65 @@ import { getUserPlan } from "@/features/deadlines/gate";
 import { UpgradeButton } from "./UpgradeButton";
 import { PortalButton } from "./PortalButton";
 
+const FEATURES = [
+  { label: "締切アイテム登録数", free: "最大 10 件", pro: "無制限" },
+  { label: "メール通知タイミング", free: "24時間前のみ", pro: "72h / 24h / 3h 前" },
+  { label: "ダッシュボード", free: "✅", pro: "✅" },
+];
+
 export default async function BillingPage() {
   const session = await requireSession();
-
   const plan = await getUserPlan(session.sub);
 
   return (
-    <main className="mx-auto max-w-2xl p-6">
+    <main className="mx-auto max-w-3xl p-6">
       <h1 className="text-2xl font-bold">プランとお支払い</h1>
 
       {plan === "pro" && (
-        <p className="mt-3 rounded bg-blue-50 px-4 py-2 text-sm text-blue-700">
+        <p className="mt-3 rounded-lg bg-indigo-50 px-4 py-2 text-sm text-indigo-700">
           ✅ 現在 <strong>Pro</strong> プランをご利用中です。
         </p>
       )}
 
-      {/* Free / Pro 比較テーブル */}
-      <div className="mt-6 overflow-hidden rounded-lg border border-slate-200">
-        <table className="w-full text-sm">
-          <thead className="bg-slate-50">
-            <tr>
-              <th className="px-4 py-3 text-left text-slate-600">機能</th>
-              <th className="px-4 py-3 text-center text-slate-600">Free</th>
-              <th className="px-4 py-3 text-center font-semibold text-blue-600">
-                Pro（980円/月）
-              </th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-slate-100">
-            <tr>
-              <td className="px-4 py-3 text-slate-700">締切アイテム登録数</td>
-              <td className="px-4 py-3 text-center text-slate-500">最大 10 件</td>
-              <td className="px-4 py-3 text-center font-medium text-blue-600">無制限</td>
-            </tr>
-            <tr>
-              <td className="px-4 py-3 text-slate-700">メール通知タイミング</td>
-              <td className="px-4 py-3 text-center text-slate-500">24時間前のみ</td>
-              <td className="px-4 py-3 text-center font-medium text-blue-600">
-                72h / 24h / 3h 前
-              </td>
-            </tr>
-            <tr>
-              <td className="px-4 py-3 text-slate-700">ダッシュボード</td>
-              <td className="px-4 py-3 text-center text-slate-500">✅</td>
-              <td className="px-4 py-3 text-center text-blue-600">✅</td>
-            </tr>
-          </tbody>
-        </table>
+      {/* Free / Pro カード比較 */}
+      <div className="mt-8 grid gap-4 sm:grid-cols-2">
+        {/* Free カード */}
+        <div className="rounded-2xl border border-gray-200 bg-white p-6">
+          <p className="text-xs font-semibold uppercase tracking-widest text-gray-400">Free</p>
+          <p className="mt-1 text-3xl font-black text-gray-900">¥0<span className="text-base font-normal text-gray-400">/月</span></p>
+          <ul className="mt-4 space-y-2">
+            {FEATURES.map((f) => (
+              <li key={f.label} className="flex justify-between text-sm">
+                <span className="text-gray-600">{f.label}</span>
+                <span className="font-medium text-gray-700">{f.free}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Pro カード */}
+        <div className="rounded-2xl border-2 border-indigo-500 bg-white p-6 shadow-lg shadow-indigo-100/50">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-widest text-indigo-600">Pro</p>
+            <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-semibold text-indigo-700">おすすめ</span>
+          </div>
+          <p className="mt-1 text-3xl font-black text-gray-900">¥980<span className="text-base font-normal text-gray-400">/月</span></p>
+          <ul className="mt-4 space-y-2">
+            {FEATURES.map((f) => (
+              <li key={f.label} className="flex justify-between text-sm">
+                <span className="text-gray-600">{f.label}</span>
+                <span className="font-semibold text-indigo-600">{f.pro}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
 
       {/* CTA */}
       <div className="mt-8">
         {plan === "pro" ? (
           <div className="space-y-3">
-            <p className="text-sm text-slate-500">
+            <p className="text-sm text-gray-500">
               解約・支払い方法の変更は Stripe 管理画面からおこなえます。
             </p>
             <PortalButton />

--- a/src/app/dashboard/DeadlineList.tsx
+++ b/src/app/dashboard/DeadlineList.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { motion, AnimatePresence } from "framer-motion";
 import {
   formatDeadline,
   getUrgencyLevel,
@@ -138,7 +139,15 @@ export default function DeadlineList({ initialItems }: Props) {
         </div>
       )}
 
-      <ul className="space-y-3">
+      <motion.ul
+        className="space-y-3"
+        initial="hidden"
+        animate="visible"
+        variants={{
+          hidden: {},
+          visible: { transition: { staggerChildren: 0.07 } },
+        }}
+      >
         {items.map((item) => {
           const urgency = getUrgencyLevel(item.deadlineAt);
           const isUpdating = updatingId === item.id;
@@ -146,8 +155,13 @@ export default function DeadlineList({ initialItems }: Props) {
           const isConfirming = confirmDeleteId === item.id;
 
           return (
-            <li
+            <motion.li
               key={item.id}
+              variants={{
+                hidden: { opacity: 0, y: 12 },
+                visible: { opacity: 1, y: 0, transition: { duration: 0.25, ease: "easeOut" } },
+              }}
+              layout
               className={`rounded-lg px-4 py-3 shadow-sm transition-opacity ${URGENCY_CLASS[urgency]} ${isUpdating || isDeleting ? "opacity-60" : ""} ${isConfirming ? "ring-1 ring-red-300" : ""}`}
             >
               <div className="flex items-start justify-between gap-3">
@@ -254,10 +268,10 @@ export default function DeadlineList({ initialItems }: Props) {
                 )}
                 </div>
               </div>
-            </li>
+            </motion.li>
           );
         })}
-      </ul>
+      </motion.ul>
     </div>
   );
 }

--- a/src/app/deadline/[id]/edit/page.tsx
+++ b/src/app/deadline/[id]/edit/page.tsx
@@ -48,7 +48,7 @@ export default async function DeadlineEditPage({ params }: Props) {
 
   return (
     <main className="mx-auto max-w-2xl p-6">
-      <h1 className="text-xl font-semibold">締切の編集</h1>
+      <h1 className="text-2xl font-bold">締切の編集</h1>
       <p className="mt-1 text-sm text-slate-500">
         <span className="text-red-500">*</span> は必須項目です
       </p>

--- a/src/app/deadline/new/DeadlineForm.tsx
+++ b/src/app/deadline/new/DeadlineForm.tsx
@@ -3,7 +3,9 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { AnimatePresence, motion } from "framer-motion";
 import { KIND_LABEL } from "@/features/deadlines/format";
+import { scaleIn } from "@/lib/motion";
 
 type FieldErrors = Record<string, string>;
 type Status = "idle" | "submitting" | "error" | "limit_exceeded";
@@ -126,7 +128,7 @@ export default function DeadlineForm(props: Props) {
   const isLimitExceeded = status === "limit_exceeded";
 
   return (
-    <form onSubmit={handleSubmit} noValidate className="mt-6 space-y-6">
+    <form onSubmit={handleSubmit} noValidate className="mt-8 space-y-5">
       {/* Free 枠上限エラー（create モードのみ） */}
       {isLimitExceeded && (
         <div
@@ -174,17 +176,19 @@ export default function DeadlineForm(props: Props) {
           placeholder="例: 株式会社テクノロジー"
           maxLength={100}
           disabled={isSubmitting}
-          className={`mt-1 w-full rounded-lg border px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 ${
+          className={`mt-1 w-full rounded-lg border px-3 py-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 ${
             fieldErrors.company_name
               ? "border-red-400 bg-red-50"
               : "border-slate-300 bg-white"
           }`}
         />
-        {fieldErrors.company_name && (
-          <p className="mt-1 text-xs text-red-600" role="alert">
-            {fieldErrors.company_name}
-          </p>
-        )}
+        <AnimatePresence>
+          {fieldErrors.company_name && (
+            <motion.p {...scaleIn} role="alert" className="mt-1 text-xs text-red-600">
+              {fieldErrors.company_name}
+            </motion.p>
+          )}
+        </AnimatePresence>
       </div>
 
       {/* 種別 */}
@@ -201,7 +205,7 @@ export default function DeadlineForm(props: Props) {
           value={kind}
           onChange={(e) => setKind(e.target.value)}
           disabled={isSubmitting}
-          className={`mt-1 w-full rounded-lg border px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 ${
+          className={`mt-1 w-full rounded-lg border px-3 py-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 ${
             fieldErrors.kind
               ? "border-red-400 bg-red-50"
               : "border-slate-300 bg-white"
@@ -214,11 +218,13 @@ export default function DeadlineForm(props: Props) {
             </option>
           ))}
         </select>
-        {fieldErrors.kind && (
-          <p className="mt-1 text-xs text-red-600" role="alert">
-            {fieldErrors.kind}
-          </p>
-        )}
+        <AnimatePresence>
+          {fieldErrors.kind && (
+            <motion.p {...scaleIn} role="alert" className="mt-1 text-xs text-red-600">
+              {fieldErrors.kind}
+            </motion.p>
+          )}
+        </AnimatePresence>
       </div>
 
       {/* 締切日時 */}
@@ -236,17 +242,19 @@ export default function DeadlineForm(props: Props) {
           value={deadlineAt}
           onChange={(e) => setDeadlineAt(e.target.value)}
           disabled={isSubmitting}
-          className={`mt-1 w-full rounded-lg border px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 ${
+          className={`mt-1 w-full rounded-lg border px-3 py-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 ${
             fieldErrors.deadline_at
               ? "border-red-400 bg-red-50"
               : "border-slate-300 bg-white"
           }`}
         />
-        {fieldErrors.deadline_at && (
-          <p className="mt-1 text-xs text-red-600" role="alert">
-            {fieldErrors.deadline_at}
-          </p>
-        )}
+        <AnimatePresence>
+          {fieldErrors.deadline_at && (
+            <motion.p {...scaleIn} role="alert" className="mt-1 text-xs text-red-600">
+              {fieldErrors.deadline_at}
+            </motion.p>
+          )}
+        </AnimatePresence>
       </div>
 
       {/* リンク（任意） */}
@@ -266,17 +274,19 @@ export default function DeadlineForm(props: Props) {
           placeholder="https://example.com/job"
           maxLength={2048}
           disabled={isSubmitting}
-          className={`mt-1 w-full rounded-lg border px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 ${
+          className={`mt-1 w-full rounded-lg border px-3 py-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 ${
             fieldErrors.link
               ? "border-red-400 bg-red-50"
               : "border-slate-300 bg-white"
           }`}
         />
-        {fieldErrors.link && (
-          <p className="mt-1 text-xs text-red-600" role="alert">
-            {fieldErrors.link}
-          </p>
-        )}
+        <AnimatePresence>
+          {fieldErrors.link && (
+            <motion.p {...scaleIn} role="alert" className="mt-1 text-xs text-red-600">
+              {fieldErrors.link}
+            </motion.p>
+          )}
+        </AnimatePresence>
       </div>
 
       {/* メモ（任意） */}
@@ -296,17 +306,19 @@ export default function DeadlineForm(props: Props) {
           maxLength={1000}
           rows={3}
           disabled={isSubmitting}
-          className={`mt-1 w-full rounded-lg border px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 ${
+          className={`mt-1 w-full rounded-lg border px-3 py-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 ${
             fieldErrors.memo
               ? "border-red-400 bg-red-50"
               : "border-slate-300 bg-white"
           }`}
         />
-        {fieldErrors.memo && (
-          <p className="mt-1 text-xs text-red-600" role="alert">
-            {fieldErrors.memo}
-          </p>
-        )}
+        <AnimatePresence>
+          {fieldErrors.memo && (
+            <motion.p {...scaleIn} role="alert" className="mt-1 text-xs text-red-600">
+              {fieldErrors.memo}
+            </motion.p>
+          )}
+        </AnimatePresence>
       </div>
 
       {/* 送信ボタン */}
@@ -314,7 +326,7 @@ export default function DeadlineForm(props: Props) {
         <button
           type="submit"
           disabled={isSubmitting || isLimitExceeded}
-          className="rounded-lg bg-blue-600 px-6 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="rounded-lg bg-indigo-600 px-6 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {isSubmitting
             ? "保存中..."

--- a/src/app/deadline/new/page.tsx
+++ b/src/app/deadline/new/page.tsx
@@ -3,7 +3,7 @@ import DeadlineForm from "./DeadlineForm";
 export default function NewDeadlinePage() {
   return (
     <main className="mx-auto max-w-2xl p-6">
-      <h1 className="text-xl font-semibold">締切の新規作成</h1>
+      <h1 className="text-2xl font-bold">締切の新規作成</h1>
       <p className="mt-1 text-sm text-slate-500">
         <span className="text-red-500">*</span> は必須項目です
       </p>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,12 +20,12 @@ export default async function RootLayout({
 
   return (
     <html lang="ja">
-      <body className="flex min-h-screen flex-col">
+      <body className="font-sans flex min-h-screen flex-col">
         {/* GTM スクリプト: body 先頭に配置（noscript フォールバック含む） */}
         <GtmScript />
         {session && <ConditionalHeader email={session.email} />}
         <div className="flex-1">{children}</div>
-        <footer className="border-t border-slate-200 bg-slate-50 py-4 text-center text-xs text-slate-500">
+        <footer className="border-t border-indigo-100 bg-gray-50 py-4 text-center text-xs text-slate-500">
           <nav className="space-x-4">
             <Link href="/terms" className="hover:underline">
               利用規約

--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -90,7 +90,7 @@ export default function LoginForm() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
-              className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-3 text-sm outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500"
             />
           </div>
 
@@ -103,7 +103,7 @@ export default function LoginForm() {
           <button
             type="submit"
             disabled={status === "loading"}
-            className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+            className="w-full rounded-lg bg-indigo-600 px-4 py-3 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-60"
           >
             {status === "loading" ? "送信中…" : "マジックリンクを送信"}
           </button>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -7,12 +7,16 @@ export const metadata = {
 
 export default function LoginPage() {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-slate-50 px-4">
-      <div className="w-full max-w-sm rounded-xl border border-slate-200 bg-white p-8 shadow-sm">
-        <h1 className="text-xl font-semibold text-slate-900">
+    <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-sm rounded-2xl border border-gray-200 bg-white p-8 shadow-lg">
+        <div className="mb-6 text-center">
+          <p className="text-2xl font-black tracking-tight text-indigo-600">〆トラ</p>
+          <p className="mt-0.5 text-xs text-gray-400">就活の締切を、逃さない。</p>
+        </div>
+        <h1 className="text-lg font-bold text-gray-900">
           ログイン / サインアップ
         </h1>
-        <p className="mt-1 text-sm text-slate-500">
+        <p className="mt-1 text-sm text-gray-500">
           メールアドレスを入力するとログインリンクを送ります。
         </p>
         {/* useSearchParams を使う LoginForm は Suspense で囲む */}

--- a/src/features/deadlines/format.ts
+++ b/src/features/deadlines/format.ts
@@ -53,9 +53,9 @@ export function getUrgencyLevel(
 
 export const URGENCY_CLASS: Record<UrgencyLevel, string> = {
   overdue: "border-l-4 border-red-500 bg-red-50",
-  today: "border-l-4 border-red-400 bg-red-50",
+  today: "border-l-4 border-orange-400 bg-orange-50",
   soon: "border-l-4 border-yellow-400 bg-yellow-50",
-  normal: "border-l-4 border-slate-200 bg-white",
+  normal: "border-l-4 border-indigo-200 bg-white",
 };
 
 export const KIND_LABEL: Record<string, string> = {
@@ -74,7 +74,7 @@ export const STATUS_LABEL: Record<string, string> = {
 
 export const STATUS_COLOR: Record<string, string> = {
   todo: "bg-slate-100 text-slate-600",
-  submitted: "bg-blue-100 text-blue-700",
+  submitted: "bg-indigo-100 text-indigo-700",
   done: "bg-green-100 text-green-700",
   canceled: "bg-slate-100 text-slate-400",
 };

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,0 +1,15 @@
+export const fadeUp = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0 },
+  transition: { duration: 0.4, ease: [0.25, 0.46, 0.45, 0.94] as const },
+};
+
+export const stagger = {
+  animate: { transition: { staggerChildren: 0.06 } },
+};
+
+export const scaleIn = {
+  initial: { opacity: 0, scale: 0.95 },
+  animate: { opacity: 1, scale: 1 },
+  transition: { duration: 0.2 },
+};


### PR DESCRIPTION
## 概要

UI/UX リデザイン全変更を main に統合する。

PR #166〜#170 は `design/brand-foundation` ベースで作成・マージされたが、`design/brand-foundation` が先に main にマージ済みだったため UI 変更が main に届いていなかった。本 PR ですべての UI 変更を main に取り込む。

## 含まれる変更

| 対象 | 内容 |
|---|---|
| `AppHeader.tsx` / `layout.tsx` | ヘッダーを Indigo ブランドカラーに刷新、ロゴ `font-black text-indigo-600`、fadeUp アニメーション |
| LP コンポーネント（7ファイル） | 大見出し `font-black tracking-tighter`、スクロール連動 `whileInView` アニメーション、`#ff385c` → indigo 統一 |
| `DeadlineList.tsx` / `format.ts` | stagger + fadeUp リスト登場アニメーション、緊急度・ステータスカラーをデザインシステムに更新 |
| `DeadlineForm.tsx` / ページ2件 | indigo ボタン・フォーカスリング、scaleIn エラーアニメーション、py-3 タッチ改善 |
| ログイン / 課金 5ファイル | ロゴ追加、カードデザイン、Free/Pro 比較カード、indigo ボタン統一 |

## Refs

Refs #160, #161, #162, #163, #164

## 動作確認

- `npx tsc --noEmit` — 型エラーなし
- `npm test` — 107 tests all passed
