### PR TITLE
design(login): 〆印章ロゴとiOS通知トーストでログインページを刷新する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource/inter": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "@fontsource/noto-sans-jp": "^5.2.9",
         "@neondatabase/serverless": "^1.0.2",
         "@prisma/adapter-neon": "^7.5.0",
@@ -2454,6 +2455,15 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
       "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "@fontsource/noto-sans-jp": "^5.2.9",
     "@neondatabase/serverless": "^1.0.2",
     "@prisma/adapter-neon": "^7.5.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,14 +8,125 @@
 @import "@fontsource/inter/900.css";
 @import "@fontsource/noto-sans-jp/400.css";
 @import "@fontsource/noto-sans-jp/700.css";
+@import "@fontsource/jetbrains-mono/400.css";
+@import "@fontsource/jetbrains-mono/600.css";
 
+/* ─── Design Tokens ─────────────────────────────────────── */
 :root {
   color-scheme: light;
+
+  /* Surface */
+  --paper:   #f7f5f0;
+  --paper-2: #ede9df;
+  --card:    #ffffff;
+
+  /* Ink (text hierarchy) */
+  --ink:   #0f0d1a;
+  --ink-2: #2c2740;
+  --ink-3: #6b6580;
+  --ink-4: #9a93ad;
+
+  /* Rule */
+  --rule: rgba(15, 13, 26, 0.08);
+
+  /* Brand */
+  --brand:     #4f46e5;
+  --brand-600: #4338ca;
+  --brand-50:  #eef2ff;
+  --brand-100: #e0e7ff;
+
+  /* Urgency */
+  --u-overdue:    #d23a3a;
+  --u-overdue-bg: #fdecec;
+  --u-today:      #e9651c;
+  --u-today-bg:   #fff1e8;
+  --u-soon:       #b0871f;
+  --u-soon-bg:    #fff7da;
+  --u-normal:     #4f46e5;
+  --u-normal-bg:  #eef2ff;
+
+  /* Status */
+  --s-done:    #1f8a5b;
+  --s-done-bg: #e6f5ed;
+
+  /* Radius */
+  --radius-card: 18px;
+
+  /* Shadow */
+  --shadow-card: 0 4px 16px rgba(15, 13, 26, 0.08);
+  --shadow-pop:  0 8px 32px rgba(15, 13, 26, 0.14);
 }
 
+/* ─── Dark theme ────────────────────────────────────────── */
+[data-theme="ink"] {
+  color-scheme: dark;
+  --paper:   #131220;
+  --paper-2: #1a1830;
+  --card:    #1f1d33;
+  --ink:     #f6f4ff;
+  --ink-2:   #d4d0f0;
+  --ink-3:   #8b86b0;
+  --ink-4:   #5a5680;
+  --rule:    rgba(246, 244, 255, 0.08);
+}
+
+/* ─── Base styles ───────────────────────────────────────── */
 body {
-  @apply bg-white text-gray-900;
+  background-color: var(--paper);
+  color: var(--ink);
   font-family: "Inter", "Noto Sans JP", sans-serif;
+  font-feature-settings: "ss01", "cv11";
+  letter-spacing: -0.01em;
+}
+
+/* ─── Kind tag colors ───────────────────────────────────── */
+.kind-es        { background: #e9defb; color: #5b3a93; }
+.kind-briefing  { background: #d8eef0; color: #1f6168; }
+.kind-interview { background: #fde0c8; color: #a04316; }
+.kind-other     { background: var(--paper-2); color: var(--ink-2); }
+
+/* ─── Motion ────────────────────────────────────────────── */
+@keyframes wiggle {
+  0%, 100% { transform: rotate(-3deg); }
+  25%       { transform: rotate(2deg); }
+  50%       { transform: rotate(-1deg); }
+  75%       { transform: rotate(3deg); }
+}
+
+@keyframes pop-in {
+  0%   { opacity: 0; transform: scale(0.85); }
+  60%  { opacity: 1; transform: scale(1.05); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+@keyframes slide-in-down {
+  from { opacity: 0; transform: translateY(-12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes draw-prog {
+  from { transform: scaleX(0); }
+  to   { transform: scaleX(var(--p, 1)); }
+}
+
+@keyframes ring-fill {
+  from { stroke-dashoffset: var(--ring-from, 138); }
+  to   { stroke-dashoffset: var(--ring-to, 0); }
+}
+
+@keyframes pulse-dot {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50%       { transform: scale(1.05); opacity: 0.85; }
+}
+
+/* Tailwind 既存のアニメーション */
+@keyframes fade-up {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes scale-in {
+  from { opacity: 0; transform: scale(0.95); }
+  to   { opacity: 1; transform: scale(1); }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -78,20 +78,28 @@ export default function LoginForm() {
           <div>
             <label
               htmlFor="email"
-              className="block text-sm font-medium text-slate-700"
+              className="block text-sm font-medium text-[var(--ink-2)]"
             >
               メールアドレス
             </label>
-            <input
-              id="email"
-              type="email"
-              required
-              autoFocus
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="you@example.com"
-              className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-3 text-sm outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500"
-            />
+            <div className="relative mt-1">
+              <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-[var(--ink-3)]">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <rect width="20" height="16" x="2" y="4" rx="2" />
+                  <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+                </svg>
+              </span>
+              <input
+                id="email"
+                type="email"
+                required
+                autoFocus
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+                className="block w-full rounded-lg border border-[var(--rule)] bg-white pl-9 pr-3 py-3 text-sm text-[var(--ink)] placeholder:text-[var(--ink-4)] outline-none focus:border-brand focus:ring-2 focus:ring-brand/20"
+              />
+            </div>
           </div>
 
           {status === "error" && (
@@ -103,7 +111,7 @@ export default function LoginForm() {
           <button
             type="submit"
             disabled={status === "loading"}
-            className="w-full rounded-lg bg-indigo-600 px-4 py-3 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-60"
+            className="w-full rounded-lg bg-[var(--ink)] px-4 py-3 text-sm font-semibold text-white hover:bg-brand transition-colors disabled:opacity-60"
           >
             {status === "loading" ? "送信中…" : "マジックリンクを送信"}
           </button>

--- a/src/app/login/_components/NotificationToast.tsx
+++ b/src/app/login/_components/NotificationToast.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function NotificationToast() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(true), 600);
+    return () => clearTimeout(t);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      style={{ animation: "slide-in-down 0.35s ease both" }}
+      className="flex items-center gap-3 rounded-2xl bg-white px-4 py-3 shadow-lg shadow-black/10"
+    >
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-brand text-white text-lg font-black">
+        〆
+      </div>
+      <div className="min-w-0">
+        <p className="text-xs font-semibold text-[var(--ink-3)]">〆トラ</p>
+        <p className="text-sm font-medium text-[var(--ink)] truncate">
+          ⏰ 明日 9:00 締切 — 〇〇商事 ES
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,28 +1,50 @@
 import { Suspense } from "react";
 import LoginForm from "./LoginForm";
+import { NotificationToast } from "./_components/NotificationToast";
 
 export const metadata = {
   title: "ログイン | 〆トラ",
 };
 
+function SealLogo() {
+  return (
+    <div
+      style={{ animation: "wiggle 2s ease-in-out infinite" }}
+      className="mx-auto flex h-20 w-20 items-center justify-center rounded-2xl bg-brand text-4xl font-black text-white shadow-lg shadow-brand/30"
+    >
+      〆
+    </div>
+  );
+}
+
 export default function LoginPage() {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-sm rounded-2xl border border-gray-200 bg-white p-8 shadow-lg">
-        <div className="mb-6 text-center">
-          <p className="text-2xl font-black tracking-tight text-indigo-600">〆トラ</p>
-          <p className="mt-0.5 text-xs text-gray-400">就活の締切を、逃さない。</p>
+    <main className="min-h-screen bg-[var(--paper)] flex flex-col items-center justify-center px-4 py-12">
+      <div className="w-full max-w-sm space-y-8">
+        {/* 〆印章ロゴ＋キャッチコピー＋通知トースト */}
+        <div className="text-center space-y-4">
+          <SealLogo />
+          <h1 className="text-2xl font-black tracking-tight text-[var(--ink)]">
+            締切を、出し忘れない人生に。
+          </h1>
+          {/* useSearchParams を使う LoginForm は Suspense で囲む */}
+          <Suspense>
+            <NotificationToast />
+          </Suspense>
         </div>
-        <h1 className="text-lg font-bold text-gray-900">
-          ログイン / サインアップ
-        </h1>
-        <p className="mt-1 text-sm text-gray-500">
-          メールアドレスを入力するとログインリンクを送ります。
-        </p>
-        {/* useSearchParams を使う LoginForm は Suspense で囲む */}
-        <Suspense>
-          <LoginForm />
-        </Suspense>
+
+        {/* ログインフォーム */}
+        <div className="rounded-2xl border border-[var(--rule)] bg-white p-8 shadow-sm">
+          <h2 className="text-lg font-bold text-[var(--ink)]">
+            ログイン / サインアップ
+          </h2>
+          <p className="mt-1 text-sm text-[var(--ink-3)]">
+            メールアドレスを入力するとログインリンクを送ります。
+          </p>
+          <Suspense>
+            <LoginForm />
+          </Suspense>
+        </div>
       </div>
     </main>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,9 +13,25 @@ const config: Config = {
           light: "#eef2ff",
           hover: "#4338ca",
         },
+        ink: "#0f0d1a",
+        paper: "#f7f5f0",
+        urgency: {
+          overdue: "#d23a3a",
+          "overdue-bg": "#fdecec",
+          today: "#e9651c",
+          "today-bg": "#fff1e8",
+          soon: "#b0871f",
+          "soon-bg": "#fff7da",
+        },
+        kind: {
+          es: { bg: "#e9defb", text: "#5b3a93" },
+          briefing: { bg: "#d8eef0", text: "#1f6168" },
+          interview: { bg: "#fde0c8", text: "#a04316" },
+        },
       },
       fontFamily: {
         sans: ["Inter", "Noto Sans JP", "sans-serif"],
+        mono: ["JetBrains Mono", "monospace"],
       },
       keyframes: {
         "fade-up": {


### PR DESCRIPTION
## Summary

- 〆印章スタイルロゴ（wiggle アニメーション）を追加
- キャッチコピー「締切を、出し忘れない人生に。」を追加
- iOS 風 NotificationToast を 600ms delay で表示
- LoginForm: メールアイコン付き input + `bg-[var(--ink)] hover:bg-brand` ボタン

Closes #182

## Test plan

- [x] `npx tsc --noEmit` — 型エラーなし
- [ ] ブラウザ確認: `/login` でトーストが 600ms 後に出現