### PR TITLE
design(header): AppHeaderをbackdrop-blurと分割ロゴで刷新する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource/inter": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "@fontsource/noto-sans-jp": "^5.2.9",
         "@neondatabase/serverless": "^1.0.2",
         "@prisma/adapter-neon": "^7.5.0",
@@ -2454,6 +2455,15 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
       "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "@fontsource/noto-sans-jp": "^5.2.9",
     "@neondatabase/serverless": "^1.0.2",
     "@prisma/adapter-neon": "^7.5.0",

--- a/src/app/_components/AppHeader.tsx
+++ b/src/app/_components/AppHeader.tsx
@@ -20,7 +20,7 @@ export function AppHeader({ email }: AppHeaderProps) {
 
   return (
     <motion.header
-      className="border-b border-indigo-100 bg-white"
+      className="sticky top-0 z-20 border-b border-[var(--rule)] bg-[var(--paper)]/90 backdrop-blur-md"
       initial={fadeUp.initial}
       animate={fadeUp.animate}
       transition={fadeUp.transition}
@@ -28,20 +28,21 @@ export function AppHeader({ email }: AppHeaderProps) {
       <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-3">
         <Link
           href="/dashboard"
-          className="text-lg font-black text-indigo-600 hover:text-indigo-700 transition-colors"
+          className="flex items-center gap-0.5 transition-opacity hover:opacity-80"
         >
-          〆トラ
+          <span className="text-lg font-black text-brand">〆</span>
+          <span className="text-lg font-black text-[var(--ink)]">トラ</span>
         </Link>
         <div className="flex items-center gap-3">
           <span
-            className="text-sm text-slate-600 hidden sm:block"
+            className="hidden text-sm text-[var(--ink-3)] sm:block"
             title={email}
           >
             {displayEmail}
           </span>
           <button
             onClick={handleLogout}
-            className="min-h-[44px] min-w-[44px] rounded-md border border-indigo-200 px-4 py-2 text-sm font-medium text-indigo-600 hover:bg-indigo-50 hover:border-indigo-300 transition-colors"
+            className="rounded-lg border border-[var(--rule)] px-4 py-2 text-sm font-medium text-[var(--ink-2)] transition-colors hover:bg-[var(--paper-2)]"
           >
             ログアウト
           </button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,14 +8,125 @@
 @import "@fontsource/inter/900.css";
 @import "@fontsource/noto-sans-jp/400.css";
 @import "@fontsource/noto-sans-jp/700.css";
+@import "@fontsource/jetbrains-mono/400.css";
+@import "@fontsource/jetbrains-mono/600.css";
 
+/* ─── Design Tokens ─────────────────────────────────────── */
 :root {
   color-scheme: light;
+
+  /* Surface */
+  --paper:   #f7f5f0;
+  --paper-2: #ede9df;
+  --card:    #ffffff;
+
+  /* Ink (text hierarchy) */
+  --ink:   #0f0d1a;
+  --ink-2: #2c2740;
+  --ink-3: #6b6580;
+  --ink-4: #9a93ad;
+
+  /* Rule */
+  --rule: rgba(15, 13, 26, 0.08);
+
+  /* Brand */
+  --brand:     #4f46e5;
+  --brand-600: #4338ca;
+  --brand-50:  #eef2ff;
+  --brand-100: #e0e7ff;
+
+  /* Urgency */
+  --u-overdue:    #d23a3a;
+  --u-overdue-bg: #fdecec;
+  --u-today:      #e9651c;
+  --u-today-bg:   #fff1e8;
+  --u-soon:       #b0871f;
+  --u-soon-bg:    #fff7da;
+  --u-normal:     #4f46e5;
+  --u-normal-bg:  #eef2ff;
+
+  /* Status */
+  --s-done:    #1f8a5b;
+  --s-done-bg: #e6f5ed;
+
+  /* Radius */
+  --radius-card: 18px;
+
+  /* Shadow */
+  --shadow-card: 0 4px 16px rgba(15, 13, 26, 0.08);
+  --shadow-pop:  0 8px 32px rgba(15, 13, 26, 0.14);
 }
 
+/* ─── Dark theme ────────────────────────────────────────── */
+[data-theme="ink"] {
+  color-scheme: dark;
+  --paper:   #131220;
+  --paper-2: #1a1830;
+  --card:    #1f1d33;
+  --ink:     #f6f4ff;
+  --ink-2:   #d4d0f0;
+  --ink-3:   #8b86b0;
+  --ink-4:   #5a5680;
+  --rule:    rgba(246, 244, 255, 0.08);
+}
+
+/* ─── Base styles ───────────────────────────────────────── */
 body {
-  @apply bg-white text-gray-900;
+  background-color: var(--paper);
+  color: var(--ink);
   font-family: "Inter", "Noto Sans JP", sans-serif;
+  font-feature-settings: "ss01", "cv11";
+  letter-spacing: -0.01em;
+}
+
+/* ─── Kind tag colors ───────────────────────────────────── */
+.kind-es        { background: #e9defb; color: #5b3a93; }
+.kind-briefing  { background: #d8eef0; color: #1f6168; }
+.kind-interview { background: #fde0c8; color: #a04316; }
+.kind-other     { background: var(--paper-2); color: var(--ink-2); }
+
+/* ─── Motion ────────────────────────────────────────────── */
+@keyframes wiggle {
+  0%, 100% { transform: rotate(-3deg); }
+  25%       { transform: rotate(2deg); }
+  50%       { transform: rotate(-1deg); }
+  75%       { transform: rotate(3deg); }
+}
+
+@keyframes pop-in {
+  0%   { opacity: 0; transform: scale(0.85); }
+  60%  { opacity: 1; transform: scale(1.05); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+@keyframes slide-in-down {
+  from { opacity: 0; transform: translateY(-12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes draw-prog {
+  from { transform: scaleX(0); }
+  to   { transform: scaleX(var(--p, 1)); }
+}
+
+@keyframes ring-fill {
+  from { stroke-dashoffset: var(--ring-from, 138); }
+  to   { stroke-dashoffset: var(--ring-to, 0); }
+}
+
+@keyframes pulse-dot {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50%       { transform: scale(1.05); opacity: 0.85; }
+}
+
+/* Tailwind 既存のアニメーション */
+@keyframes fade-up {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes scale-in {
+  from { opacity: 0; transform: scale(0.95); }
+  to   { opacity: 1; transform: scale(1); }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,9 +13,25 @@ const config: Config = {
           light: "#eef2ff",
           hover: "#4338ca",
         },
+        ink: "#0f0d1a",
+        paper: "#f7f5f0",
+        urgency: {
+          overdue: "#d23a3a",
+          "overdue-bg": "#fdecec",
+          today: "#e9651c",
+          "today-bg": "#fff1e8",
+          soon: "#b0871f",
+          "soon-bg": "#fff7da",
+        },
+        kind: {
+          es: { bg: "#e9defb", text: "#5b3a93" },
+          briefing: { bg: "#d8eef0", text: "#1f6168" },
+          interview: { bg: "#fde0c8", text: "#a04316" },
+        },
       },
       fontFamily: {
         sans: ["Inter", "Noto Sans JP", "sans-serif"],
+        mono: ["JetBrains Mono", "monospace"],
       },
       keyframes: {
         "fade-up": {


### PR DESCRIPTION
## Summary

- sticky + backdrop-blur-md による半透明ヘッダー
- ロゴ「〆」(brand) + 「トラ」(ink) 分割スタイル
- 色トークンを CSS 変数に統一（border-[var(--rule)] 等）

Closes #188

## Test plan

- [x] `npx tsc --noEmit` — 型エラーなし
- [ ] ブラウザ確認: ダッシュボードスクロール時にヘッダーがblur表示される