### PR TITLE
design: UI/UXデザインファイル全実装 (#181〜#189)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource/inter": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "@fontsource/noto-sans-jp": "^5.2.9",
         "@neondatabase/serverless": "^1.0.2",
         "@prisma/adapter-neon": "^7.5.0",
@@ -2454,6 +2455,15 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
       "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "@fontsource/noto-sans-jp": "^5.2.9",
     "@neondatabase/serverless": "^1.0.2",
     "@prisma/adapter-neon": "^7.5.0",

--- a/src/app/_components/AppHeader.tsx
+++ b/src/app/_components/AppHeader.tsx
@@ -20,7 +20,7 @@ export function AppHeader({ email }: AppHeaderProps) {
 
   return (
     <motion.header
-      className="border-b border-indigo-100 bg-white"
+      className="sticky top-0 z-20 border-b border-[var(--rule)] bg-[var(--paper)]/90 backdrop-blur-md"
       initial={fadeUp.initial}
       animate={fadeUp.animate}
       transition={fadeUp.transition}
@@ -28,20 +28,21 @@ export function AppHeader({ email }: AppHeaderProps) {
       <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-3">
         <Link
           href="/dashboard"
-          className="text-lg font-black text-indigo-600 hover:text-indigo-700 transition-colors"
+          className="flex items-center gap-0.5 transition-opacity hover:opacity-80"
         >
-          〆トラ
+          <span className="text-lg font-black text-brand">〆</span>
+          <span className="text-lg font-black text-[var(--ink)]">トラ</span>
         </Link>
         <div className="flex items-center gap-3">
           <span
-            className="text-sm text-slate-600 hidden sm:block"
+            className="hidden text-sm text-[var(--ink-3)] sm:block"
             title={email}
           >
             {displayEmail}
           </span>
           <button
             onClick={handleLogout}
-            className="min-h-[44px] min-w-[44px] rounded-md border border-indigo-200 px-4 py-2 text-sm font-medium text-indigo-600 hover:bg-indigo-50 hover:border-indigo-300 transition-colors"
+            className="rounded-lg border border-[var(--rule)] px-4 py-2 text-sm font-medium text-[var(--ink-2)] transition-colors hover:bg-[var(--paper-2)]"
           >
             ログアウト
           </button>

--- a/src/app/dashboard/DeadlineList.tsx
+++ b/src/app/dashboard/DeadlineList.tsx
@@ -6,40 +6,111 @@ import { motion, AnimatePresence } from "framer-motion";
 import {
   formatDeadline,
   getUrgencyLevel,
-  URGENCY_CLASS,
   KIND_LABEL,
   STATUS_LABEL,
-  STATUS_COLOR,
 } from "@/features/deadlines/format";
+import { UrgencyRing } from "./UrgencyRing";
 
 export type DeadlineItem = {
   id: string;
   companyName: string;
   kind: "es" | "briefing" | "interview" | "other";
-  deadlineAt: string; // ISO string（Server Component から文字列で渡す）
+  deadlineAt: string;
   status: "todo" | "submitted" | "done" | "canceled";
   link: string | null;
   memo: string | null;
 };
 
+type FilterState = "all" | "todo" | "done";
+
+const STATUS_CYCLE: Record<DeadlineItem["status"], DeadlineItem["status"]> = {
+  todo: "submitted",
+  submitted: "done",
+  done: "todo",
+  canceled: "todo",
+};
+
+const STATUS_PILL: Record<
+  DeadlineItem["status"],
+  { label: string; className: string }
+> = {
+  todo: {
+    label: STATUS_LABEL.todo,
+    className: "bg-[var(--paper-2)] text-[var(--ink-2)]",
+  },
+  submitted: {
+    label: STATUS_LABEL.submitted,
+    className: "bg-brand/10 text-brand",
+  },
+  done: {
+    label: STATUS_LABEL.done,
+    className: "bg-[var(--s-done-bg)] text-[var(--s-done)]",
+  },
+  canceled: {
+    label: STATUS_LABEL.canceled,
+    className: "bg-[var(--paper-2)] text-[var(--ink-4)]",
+  },
+};
+
+const FILTER_CHIPS: { key: FilterState; label: string }[] = [
+  { key: "all", label: "全て" },
+  { key: "todo", label: "未対応" },
+  { key: "done", label: "済" },
+];
+
 type Props = {
   initialItems: DeadlineItem[];
 };
 
-/**
- * ダッシュボード締切一覧 クライアントコンポーネント
- *
- * - initialItems を Server Component から受け取り、ローカル state で管理する
- * - ステータス変更は楽観的更新 → PATCH /api/deadlines/:id → 失敗時ロールバック
- * - 0件のときは空状態 UI（2件登録を促す導線）を表示する
- */
 export default function DeadlineList({ initialItems }: Props) {
   const [items, setItems] = useState<DeadlineItem[]>(initialItems);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
-  const [editingStatusId, setEditingStatusId] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [filter, setFilter] = useState<FilterState>("all");
+
+  const filteredItems = items.filter((item) => {
+    if (filter === "todo") return item.status === "todo";
+    if (filter === "done")
+      return (
+        item.status === "done" ||
+        item.status === "submitted" ||
+        item.status === "canceled"
+      );
+    return true;
+  });
+
+  async function handleStatusChange(id: string, newStatus: string) {
+    const prevItems = items;
+    setUpdatingId(id);
+    setErrorMsg(null);
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === id
+          ? { ...item, status: newStatus as DeadlineItem["status"] }
+          : item,
+      ),
+    );
+    try {
+      const res = await fetch(`/api/deadlines/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: newStatus }),
+      });
+      if (!res.ok) {
+        const data = (await res.json()) as { error?: string };
+        throw new Error(data.error ?? "ステータスの更新に失敗しました");
+      }
+    } catch (err) {
+      setItems(prevItems);
+      setErrorMsg(
+        err instanceof Error ? err.message : "ステータスの更新に失敗しました",
+      );
+    } finally {
+      setUpdatingId(null);
+    }
+  }
 
   function handleDelete(id: string) {
     setConfirmDeleteId(id);
@@ -50,76 +121,36 @@ export default function DeadlineList({ initialItems }: Props) {
     setConfirmDeleteId(null);
     setDeletingId(id);
     setErrorMsg(null);
-
     setItems((prev) => prev.filter((item) => item.id !== id));
-
     try {
       const res = await fetch(`/api/deadlines/${id}`, { method: "DELETE" });
-
       if (!res.ok) {
         const data = (await res.json()) as { error?: string };
         throw new Error(data.error ?? "削除に失敗しました");
       }
     } catch (err) {
       setItems(prevItems);
-      setErrorMsg(
-        err instanceof Error ? err.message : "削除に失敗しました",
-      );
+      setErrorMsg(err instanceof Error ? err.message : "削除に失敗しました");
     } finally {
       setDeletingId(null);
     }
   }
 
-  async function handleStatusChange(id: string, newStatus: string) {
-    const prevItems = items; // ロールバック用に退避
-
-    setUpdatingId(id);
-    setErrorMsg(null);
-
-    // 楽観的更新
-    setItems((prev) =>
-      prev.map((item) =>
-        item.id === id
-          ? { ...item, status: newStatus as DeadlineItem["status"] }
-          : item,
-      ),
-    );
-
-    try {
-      const res = await fetch(`/api/deadlines/${id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status: newStatus }),
-      });
-
-      if (!res.ok) {
-        const data = (await res.json()) as { error?: string };
-        throw new Error(data.error ?? "ステータスの更新に失敗しました");
-      }
-    } catch (err) {
-      setItems(prevItems); // ロールバック
-      setErrorMsg(
-        err instanceof Error ? err.message : "ステータスの更新に失敗しました",
-      );
-    } finally {
-      setUpdatingId(null);
-    }
-  }
-
-  // ── 空状態 ──────────────────────────────────────────────────────────────
   if (items.length === 0) {
     return (
-      <div className="mt-8 rounded-lg border-2 border-dashed border-slate-200 py-14 text-center">
-        <p className="text-sm font-medium text-slate-600">
+      <div className="mt-8 flex flex-col items-center gap-4 py-16 text-center">
+        <span className="text-5xl font-black text-[var(--ink-4)]">〆</span>
+        <p className="text-sm font-medium text-[var(--ink-3)]">
           締切アイテムがまだありません
         </p>
-        <p className="mt-1 text-xs text-slate-400">
-          まずは<span className="font-semibold text-slate-600">2件登録</span>
-          して、締切管理をスタートしましょう 🎯
+        <p className="text-xs text-[var(--ink-4)]">
+          まずは
+          <span className="font-semibold text-[var(--ink-2)]">2件登録</span>
+          して、締切管理をスタートしましょう
         </p>
         <Link
           href="/deadline/new"
-          className="mt-5 inline-block rounded-md bg-slate-900 px-5 py-2 text-sm font-medium text-white hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
+          className="mt-2 rounded-xl bg-brand px-5 py-2.5 text-sm font-semibold text-white hover:bg-brand-hover"
         >
           + 締切を登録する
         </Link>
@@ -127,151 +158,226 @@ export default function DeadlineList({ initialItems }: Props) {
     );
   }
 
-  // ── 一覧 ────────────────────────────────────────────────────────────────
   return (
     <div className="mt-4">
+      {/* フィルターチップ */}
+      <div className="flex gap-2">
+        {FILTER_CHIPS.map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => setFilter(key)}
+            className={`rounded-full px-4 py-1.5 text-sm font-semibold transition-colors ${
+              filter === key
+                ? "bg-[var(--ink)] text-white"
+                : "bg-[var(--paper-2)] text-[var(--ink-3)] hover:text-[var(--ink-2)]"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
       {errorMsg && (
         <div
           role="alert"
-          className="mb-3 rounded-md bg-red-50 px-4 py-2 text-sm text-red-600"
+          className="mt-3 rounded-xl bg-[var(--u-overdue-bg)] px-4 py-2 text-sm text-[var(--u-overdue)]"
         >
           ⚠ {errorMsg}
         </div>
       )}
 
-      <motion.ul
-        className="space-y-3"
-        initial="hidden"
-        animate="visible"
-        variants={{
-          hidden: {},
-          visible: { transition: { staggerChildren: 0.07 } },
-        }}
-      >
-        {items.map((item) => {
-          const urgency = getUrgencyLevel(item.deadlineAt);
-          const isUpdating = updatingId === item.id;
-          const isDeleting = deletingId === item.id;
-          const isConfirming = confirmDeleteId === item.id;
+      {filteredItems.length === 0 ? (
+        <div className="mt-8 py-12 text-center text-sm text-[var(--ink-4)]">
+          該当する締切はありません
+        </div>
+      ) : (
+        <motion.ul
+          className="mt-4 space-y-3"
+          initial="hidden"
+          animate="visible"
+          variants={{
+            hidden: {},
+            visible: { transition: { staggerChildren: 0.07 } },
+          }}
+        >
+          <AnimatePresence>
+            {filteredItems.map((item) => {
+              const urgency = getUrgencyLevel(item.deadlineAt);
+              const isUpdating = updatingId === item.id;
+              const isDeleting = deletingId === item.id;
+              const isConfirming = confirmDeleteId === item.id;
+              const isDone =
+                item.status === "done" || item.status === "canceled";
 
-          return (
-            <motion.li
-              key={item.id}
-              variants={{
-                hidden: { opacity: 0, y: 12 },
-                visible: { opacity: 1, y: 0, transition: { duration: 0.25, ease: "easeOut" } },
-              }}
-              layout
-              className={`rounded-lg px-4 py-3 shadow-sm transition-opacity ${URGENCY_CLASS[urgency]} ${isUpdating || isDeleting ? "opacity-60" : ""} ${isConfirming ? "ring-1 ring-red-300" : ""}`}
-            >
-              <div className="flex items-start justify-between gap-3">
-                {/* 左列：企業名・種別・日時・リンク・メモ */}
-                <div className="min-w-0 flex-1">
-                  <p className="truncate font-semibold text-slate-900">
-                    {item.companyName}
-                  </p>
-                  <p className="mt-0.5 text-xs text-slate-500">
-                    <span className="rounded bg-slate-100 px-1 py-0.5 font-medium text-slate-600">
-                      {KIND_LABEL[item.kind]}
-                    </span>
-                    {"　"}
-                    {formatDeadline(item.deadlineAt)}
-                  </p>
-                  {item.link && (
-                    <a
-                      href={item.link}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="mt-0.5 inline-block max-w-xs truncate text-xs text-blue-600 underline"
-                    >
-                      公募リンク ↗
-                    </a>
-                  )}
-                  {item.memo && (
-                    <p className="mt-1 line-clamp-1 text-xs text-slate-400">
-                      {item.memo}
-                    </p>
-                  )}
-                </div>
+              const pillStyle = STATUS_PILL[item.status];
 
-                {/* 右列：ステータス＋編集リンク＋削除ボタン */}
-                <div className="flex shrink-0 items-center gap-2">
-                {editingStatusId === item.id ? (
-                  <select
-                    value={item.status}
-                    autoFocus
-                    disabled={isUpdating || isDeleting}
-                    onChange={(e) => {
-                      handleStatusChange(item.id, e.target.value);
-                      setEditingStatusId(null);
-                    }}
-                    onBlur={() => setEditingStatusId(null)}
-                    aria-label={`${item.companyName}のステータスを変更`}
-                    className="cursor-pointer rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    {Object.entries(STATUS_LABEL).map(([value, label]) => (
-                      <option key={value} value={value}>
-                        {label}
-                      </option>
-                    ))}
-                  </select>
-                ) : (
-                  <button
-                    onClick={() => setEditingStatusId(item.id)}
-                    disabled={isUpdating || isDeleting}
-                    aria-label={`${item.companyName}のステータスを変更`}
-                    className={`rounded px-2 py-1 text-xs font-medium ${STATUS_COLOR[item.status]} disabled:cursor-not-allowed disabled:opacity-50`}
-                  >
-                    {STATUS_LABEL[item.status]}
-                  </button>
-                )}
-                <Link
-                  href={`/deadline/${item.id}/edit`}
-                  aria-label={`${item.companyName}を編集`}
-                  className={`rounded p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700 ${isUpdating || isDeleting ? "pointer-events-none opacity-50" : ""}`}
+              const stripeColor = {
+                overdue: "var(--u-overdue)",
+                today: "var(--u-today)",
+                soon: "var(--u-soon)",
+                normal: "transparent",
+              }[urgency];
+
+              return (
+                <motion.li
+                  key={item.id}
+                  variants={{
+                    hidden: { opacity: 0, y: 12 },
+                    visible: {
+                      opacity: 1,
+                      y: 0,
+                      transition: { duration: 0.25, ease: "easeOut" },
+                    },
+                  }}
+                  layout
+                  exit={{ opacity: 0, scale: 0.96 }}
+                  className={`relative overflow-hidden rounded-[var(--radius-card)] bg-[var(--card)] p-4 shadow-[var(--shadow-card)] transition-all hover:-translate-y-px hover:shadow-[var(--shadow-pop)] ${
+                    isUpdating || isDeleting ? "opacity-60" : ""
+                  } ${isConfirming ? "ring-1 ring-[var(--u-overdue)]" : ""} ${
+                    isDone ? "opacity-70" : ""
+                  }`}
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536M9 13l6.586-6.586a2 2 0 112.828 2.828L11.828 15.828a2 2 0 01-1.414.586H7v-3a2 2 0 01.586-1.414z" />
-                  </svg>
-                </Link>
-                {isConfirming ? (
-                  <div className="flex items-center gap-1">
-                    <span className="text-xs text-slate-600">削除しますか？</span>
-                    <button
-                      onClick={() => executeDelete(item.id)}
-                      className="rounded px-2 py-0.5 text-xs font-medium text-white bg-red-500 hover:bg-red-600"
-                    >
-                      削除
-                    </button>
-                    <button
-                      onClick={() => setConfirmDeleteId(null)}
-                      className="rounded px-2 py-0.5 text-xs font-medium text-slate-600 hover:bg-slate-100"
-                    >
-                      キャンセル
-                    </button>
+                  {/* 緊急度ストライプ */}
+                  <div
+                    className="absolute left-0 top-3 bottom-3 w-1 rounded-full"
+                    style={{ background: stripeColor }}
+                    aria-hidden="true"
+                  />
+
+                  <div className="flex items-center gap-3 pl-3">
+                    {/* UrgencyRing */}
+                    <UrgencyRing iso={item.deadlineAt} urgency={urgency} />
+
+                    {/* メイン情報 */}
+                    <div className="min-w-0 flex-1">
+                      <p
+                        className={`truncate font-semibold text-[var(--ink)] ${
+                          isDone ? "line-through" : ""
+                        }`}
+                      >
+                        {item.companyName}
+                      </p>
+                      <p className="mt-0.5 flex items-center gap-1.5 text-xs text-[var(--ink-3)]">
+                        <span
+                          className={`kind-${item.kind} rounded-full px-2 py-0.5 text-[11px] font-semibold`}
+                        >
+                          {KIND_LABEL[item.kind]}
+                        </span>
+                        <span>{formatDeadline(item.deadlineAt)}</span>
+                      </p>
+                      {item.link && (
+                        <a
+                          href={item.link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="mt-0.5 inline-block max-w-xs truncate text-xs text-brand underline"
+                        >
+                          公募リンク ↗
+                        </a>
+                      )}
+                      {item.memo && (
+                        <p className="mt-1 line-clamp-1 text-xs text-[var(--ink-4)]">
+                          {item.memo}
+                        </p>
+                      )}
+                    </div>
+
+                    {/* 右列: ステータスピル + 操作 */}
+                    <div className="flex shrink-0 flex-col items-end gap-2">
+                      <button
+                        onClick={() =>
+                          handleStatusChange(item.id, STATUS_CYCLE[item.status])
+                        }
+                        disabled={isUpdating || isDeleting}
+                        aria-label={`${item.companyName}のステータスを変更`}
+                        className={`rounded-full px-3 py-1 text-xs font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${pillStyle.className}`}
+                      >
+                        {pillStyle.label}
+                      </button>
+
+                      <div className="flex items-center gap-1">
+                        <Link
+                          href={`/deadline/${item.id}/edit`}
+                          aria-label={`${item.companyName}を編集`}
+                          className="rounded-lg p-1.5 text-[var(--ink-4)] hover:bg-[var(--paper-2)] hover:text-[var(--ink-2)]"
+                        >
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            className="h-4 w-4"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={2}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M15.232 5.232l3.536 3.536M9 13l6.586-6.586a2 2 0 112.828 2.828L11.828 15.828a2 2 0 01-1.414.586H7v-3a2 2 0 01.586-1.414z"
+                            />
+                          </svg>
+                        </Link>
+
+                        {isConfirming ? (
+                          <div className="flex items-center gap-1">
+                            <button
+                              onClick={() => executeDelete(item.id)}
+                              className="rounded-lg px-2 py-1 text-xs font-semibold text-white"
+                              style={{ background: "var(--u-overdue)" }}
+                            >
+                              削除
+                            </button>
+                            <button
+                              onClick={() => setConfirmDeleteId(null)}
+                              className="rounded-lg px-2 py-1 text-xs text-[var(--ink-3)] hover:bg-[var(--paper-2)]"
+                            >
+                              ×
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            onClick={() => handleDelete(item.id)}
+                            disabled={isUpdating || isDeleting}
+                            aria-label={`${item.companyName}を削除`}
+                            className="rounded-lg p-1.5 text-[var(--ink-4)] hover:bg-[var(--u-overdue-bg)] hover:text-[var(--u-overdue)] disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            {isDeleting ? (
+                              <span className="text-[10px]">…</span>
+                            ) : (
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                className="h-4 w-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9 7h6m2 0a1 1 0 00-1-1h-4a1 1 0 00-1 1H5"
+                                />
+                              </svg>
+                            )}
+                          </button>
+                        )}
+                      </div>
+                    </div>
                   </div>
-                ) : (
-                  <button
-                    onClick={() => handleDelete(item.id)}
-                    disabled={isUpdating || isDeleting}
-                    aria-label={`${item.companyName}を削除`}
-                    className="rounded p-1 text-slate-400 hover:bg-red-50 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    {isDeleting ? (
-                      <span className="text-xs">削除中…</span>
-                    ) : (
-                      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9 7h6m2 0a1 1 0 00-1-1h-4a1 1 0 00-1 1H5" />
-                      </svg>
-                    )}
-                  </button>
-                )}
-                </div>
-              </div>
-            </motion.li>
-          );
-        })}
-      </motion.ul>
+                </motion.li>
+              );
+            })}
+          </AnimatePresence>
+        </motion.ul>
+      )}
+
+      {/* FAB */}
+      <Link
+        href="/deadline/new"
+        aria-label="締切を追加"
+        className="fixed bottom-6 right-6 flex h-14 w-14 items-center justify-center rounded-full bg-brand text-2xl font-black text-white shadow-[var(--shadow-pop)] transition-transform hover:bg-brand-hover active:scale-95"
+      >
+        +
+      </Link>
     </div>
   );
 }

--- a/src/app/dashboard/HeroCard.tsx
+++ b/src/app/dashboard/HeroCard.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { KIND_LABEL } from "@/features/deadlines/format";
+import type { DeadlineItem } from "./DeadlineList";
+
+const GREETINGS = [
+  [5, 11, "GOOD MORNING"],
+  [11, 17, "GOOD AFTERNOON"],
+  [17, 22, "GOOD EVENING"],
+  [22, 24, "GOOD NIGHT"],
+  [0, 5, "GOOD NIGHT"],
+] as const;
+
+function greeting(h: number) {
+  return (
+    GREETINGS.find(([s, e]) => h >= s && h < e)?.[2] ?? "HELLO"
+  );
+}
+
+function timeLeft(iso: string) {
+  const diffMs = new Date(iso).getTime() - Date.now();
+  if (diffMs < 0) return { value: 0, unit: "期限切れ", overdue: true, progress: 1 };
+  const hours = diffMs / (1000 * 60 * 60);
+  const days = Math.floor(hours / 24);
+  const progress = Math.min(1, Math.max(0, (14 - days) / 14));
+  if (days > 0) return { value: days, unit: "日", overdue: false, progress };
+  return { value: Math.ceil(hours), unit: "時間", overdue: false, progress };
+}
+
+export function HeroCard({ item }: { item: DeadlineItem }) {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const t = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(t);
+  }, []);
+
+  const h = now.getHours();
+  const greet = greeting(h);
+  const dateLabel = now.toLocaleDateString("ja-JP", {
+    month: "long",
+    day: "numeric",
+    weekday: "short",
+  });
+
+  const { value, unit, overdue, progress } = timeLeft(item.deadlineAt);
+
+  return (
+    <div
+      className="relative overflow-hidden rounded-[var(--radius-card)] p-6 text-white shadow-[var(--shadow-pop)]"
+      style={{
+        background: "var(--ink)",
+        animation: "pop-in 0.4s ease both",
+      }}
+    >
+      {/* 装飾 〆 */}
+      <span
+        className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 select-none text-[120px] font-black leading-none"
+        style={{ color: "rgba(246,244,255,0.06)" }}
+        aria-hidden="true"
+      >
+        〆
+      </span>
+
+      {/* パルスドット */}
+      <div
+        className="absolute right-4 top-4 h-2 w-2 rounded-full bg-white"
+        style={{ animation: "pulse-dot 2s ease-in-out infinite" }}
+        aria-hidden="true"
+      />
+
+      {/* 挨拶 */}
+      <p className="text-xs font-semibold uppercase tracking-widest opacity-60">
+        {greet} · {dateLabel}
+      </p>
+
+      {/* カウントダウン */}
+      <div className="mt-2 flex items-end gap-1">
+        <span
+          className="font-mono text-6xl font-black leading-none tabular-nums"
+          style={{ color: overdue ? "var(--u-overdue)" : "white" }}
+        >
+          {value}
+        </span>
+        <span className="mb-1 text-lg font-semibold opacity-80">{unit}</span>
+      </div>
+
+      {/* 企業名・種別 */}
+      <p className="mt-3 truncate font-semibold opacity-90">{item.companyName}</p>
+      <span
+        className={`kind-${item.kind} mt-1 inline-block rounded-full px-2 py-0.5 text-xs font-semibold`}
+      >
+        {KIND_LABEL[item.kind]}
+      </span>
+
+      {/* プログレスバー */}
+      <div className="mt-4 h-1.5 overflow-hidden rounded-full bg-white/20">
+        <div
+          className="h-full rounded-full bg-white/80"
+          style={{ width: `${progress * 100}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/UrgencyRing.tsx
+++ b/src/app/dashboard/UrgencyRing.tsx
@@ -1,0 +1,76 @@
+import type { UrgencyLevel } from "@/features/deadlines/format";
+
+const RING_COLOR: Record<UrgencyLevel, string> = {
+  overdue: "var(--u-overdue)",
+  today: "var(--u-today)",
+  soon: "var(--u-soon)",
+  normal: "var(--u-normal)",
+};
+
+const R = 22;
+const CIRC = 2 * Math.PI * R;
+
+function daysLeft(iso: string): number {
+  return (new Date(iso).getTime() - Date.now()) / (1000 * 60 * 60 * 24);
+}
+
+export function UrgencyRing({
+  iso,
+  urgency,
+}: {
+  iso: string;
+  urgency: UrgencyLevel;
+}) {
+  const days = daysLeft(iso);
+  const isOverdue = urgency === "overdue";
+
+  const ratio = isOverdue ? 1 : Math.min(1, Math.max(0, (14 - days) / 14));
+  const offset = CIRC * (1 - ratio);
+
+  const label = isOverdue ? "!" : String(Math.ceil(Math.max(0, days)));
+  const color = RING_COLOR[urgency];
+
+  return (
+    <div className="relative flex h-[52px] w-[52px] shrink-0 items-center justify-center">
+      <svg
+        width="52"
+        height="52"
+        viewBox="0 0 52 52"
+        className="-rotate-90"
+        aria-hidden="true"
+      >
+        <circle
+          cx="26"
+          cy="26"
+          r={R}
+          fill="none"
+          stroke="rgba(15,13,26,0.06)"
+          strokeWidth="4"
+        />
+        <circle
+          cx="26"
+          cy="26"
+          r={R}
+          fill="none"
+          stroke={color}
+          strokeWidth="4"
+          strokeLinecap="round"
+          strokeDasharray={CIRC}
+          strokeDashoffset={offset}
+          style={{ animation: "ring-fill 1s ease both" }}
+        />
+      </svg>
+      <div
+        className="absolute inset-0 flex flex-col items-center justify-center"
+        style={{ color }}
+      >
+        <span className="font-mono text-sm font-bold leading-none tabular-nums">
+          {label}
+        </span>
+        {!isOverdue && (
+          <span className="text-[9px] leading-none opacity-70">日</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,25 +1,16 @@
-
 import Link from "next/link";
 import { requireSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import DeadlineList, { type DeadlineItem } from "./DeadlineList";
+import { HeroCard } from "./HeroCard";
 import { FREE_ITEM_LIMIT, isProUser } from "@/features/deadlines/gate";
 import { trackEvent } from "@/features/analytics";
-import { getUrgencyLevel } from "@/features/deadlines/format";
 
-/**
- * /dashboard – Server Component
- *
- * - 未ログイン → /login にリダイレクト
- * - ログイン済 → Prisma で deadline_at 昇順取得し DeadlineList に渡す
- */
 export default async function DashboardPage() {
   const session = await requireSession();
 
-  // 2. ダッシュボード表示の計測（重複は集計側で吸収する設計・エラーはキャッチ済みなのでawait可）
   await trackEvent({ name: "dashboard_viewed", userId: session.sub });
 
-  // 3. ログインユーザーのアイテムを deadline_at 昇順で取得 & Pro 判定を並列実行
   const [rows, pro] = await Promise.all([
     prisma.deadlineItem.findMany({
       where: { userId: session.sub },
@@ -37,80 +28,43 @@ export default async function DashboardPage() {
     isProUser(session.sub),
   ]);
 
-  // 4. Date → ISO string に変換（Client Component へのシリアライズ要件）
   const items: DeadlineItem[] = rows.map((row) => ({
     ...row,
     deadlineAt: row.deadlineAt.toISOString(),
   }));
 
-  // Free ユーザーが上限に達しているか
   const isAtFreeLimit = !pro && items.length >= FREE_ITEM_LIMIT;
-
-  const todoCount = items.filter((i) => i.status === "todo").length;
-  const overdueCount = items.filter(
-    (i) => i.status === "todo" && getUrgencyLevel(i.deadlineAt) === "overdue",
-  ).length;
+  const nextItem = items.find((i) => i.status === "todo") ?? null;
 
   return (
-    <main className="mx-auto max-w-3xl p-6">
-      {/* ヘッダー */}
-      <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold text-slate-900">ダッシュボード</h1>
-        <Link
-          href="/deadline/new"
-          className="rounded-md bg-slate-900 px-3 py-2 text-sm font-medium text-white hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
-        >
-          + 締切を追加
-        </Link>
-      </div>
-
-      {/* 件数サマリー */}
-      {items.length > 0 && (
-        <div className="mt-4 grid grid-cols-3 gap-3">
-          <div className="rounded-lg border border-slate-200 bg-white px-4 py-3 text-center">
-            <p className="text-2xl font-bold text-slate-900">{items.length}</p>
-            <p className="mt-0.5 text-xs text-slate-500">登録中</p>
-          </div>
-          <div className="rounded-lg border border-slate-200 bg-white px-4 py-3 text-center">
-            <p className="text-2xl font-bold text-slate-900">{todoCount}</p>
-            <p className="mt-0.5 text-xs text-slate-500">未対応</p>
-          </div>
-          <div
-            className={`rounded-lg border px-4 py-3 text-center ${
-              overdueCount > 0
-                ? "border-red-200 bg-red-50"
-                : "border-slate-200 bg-white"
-            }`}
-          >
-            <p
-              className={`text-2xl font-bold ${
-                overdueCount > 0 ? "text-red-600" : "text-slate-900"
-              }`}
-            >
-              {overdueCount}
-            </p>
-            <p className="mt-0.5 text-xs text-slate-500">期限切れ</p>
-          </div>
+    <main className="mx-auto max-w-3xl px-4 py-6">
+      {/* HeroCard: 次の締切カウントダウン */}
+      {nextItem && (
+        <div className="mb-6">
+          <HeroCard item={nextItem} />
         </div>
       )}
 
       {/* Free 枠上限バナー */}
       {isAtFreeLimit && (
-        <div className="mt-4 flex items-center justify-between rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm">
-          <p className="text-amber-800">
-            <span className="font-semibold">Free プランの上限（{FREE_ITEM_LIMIT}件）に達しています。</span>
-            {"　"}新しい締切を追加するには Pro へのアップグレードが必要です。
+        <div className="mb-4 flex items-center justify-between rounded-[var(--radius-card)] border border-[var(--u-soon-bg)] bg-[var(--u-soon-bg)] px-4 py-3 text-sm">
+          <p className="text-[var(--u-soon)]">
+            <span className="font-semibold">
+              Free プランの上限（{FREE_ITEM_LIMIT}件）に達しています。
+            </span>
+            {"　"}
+            Pro へのアップグレードで無制限に追加できます。
           </p>
           <Link
             href="/billing"
-            className="ml-4 shrink-0 rounded-md bg-amber-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-1"
+            className="ml-4 shrink-0 rounded-lg bg-[var(--u-soon)] px-3 py-1.5 text-xs font-semibold text-white hover:opacity-90"
           >
             Pro にアップグレード
           </Link>
         </div>
       )}
 
-      {/* 締切一覧（クライアントコンポーネント） */}
+      {/* 締切一覧 */}
       <DeadlineList initialItems={items} />
     </main>
   );

--- a/src/app/deadline/new/DeadlineForm.tsx
+++ b/src/app/deadline/new/DeadlineForm.tsx
@@ -10,8 +10,6 @@ import { scaleIn } from "@/lib/motion";
 type FieldErrors = Record<string, string>;
 type Status = "idle" | "submitting" | "error" | "limit_exceeded";
 
-const KIND_OPTIONS = Object.entries(KIND_LABEL) as [string, string][];
-
 type CreateProps = { mode: "create" };
 type EditProps = {
   mode: "edit";
@@ -24,6 +22,56 @@ type EditProps = {
 };
 
 type Props = CreateProps | EditProps;
+
+const KIND_TILES = [
+  { value: "es", label: "ES", icon: "📝", desc: "エントリーシート" },
+  { value: "briefing", label: "説明会", icon: "📅", desc: "イベント・会社説明会" },
+  { value: "interview", label: "面接", icon: "🗣️", desc: "面接・選考" },
+  { value: "other", label: "その他", icon: "📌", desc: "その他の選考" },
+] as const;
+
+const QUICK_TIMES = [
+  {
+    label: "今夜",
+    getDate() {
+      const d = new Date();
+      d.setHours(23, 59, 0, 0);
+      return d;
+    },
+  },
+  {
+    label: "明日",
+    getDate() {
+      const d = new Date();
+      d.setDate(d.getDate() + 1);
+      d.setHours(23, 59, 0, 0);
+      return d;
+    },
+  },
+  {
+    label: "3日後",
+    getDate() {
+      const d = new Date();
+      d.setDate(d.getDate() + 3);
+      d.setHours(23, 59, 0, 0);
+      return d;
+    },
+  },
+  {
+    label: "1週間後",
+    getDate() {
+      const d = new Date();
+      d.setDate(d.getDate() + 7);
+      d.setHours(23, 59, 0, 0);
+      return d;
+    },
+  },
+] as const;
+
+function toDatetimeLocal(d: Date): string {
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}`;
+}
 
 export default function DeadlineForm(props: Props) {
   const router = useRouter();
@@ -81,7 +129,6 @@ export default function DeadlineForm(props: Props) {
         body: JSON.stringify({
           company_name: companyName.trim(),
           kind,
-          // datetime-local は TZ なしで返るため +09:00 を付与して JST を明示する
           deadline_at: deadlineAt ? deadlineAt + "+09:00" : "",
           link: link.trim() || undefined,
           memo: memo.trim() || undefined,
@@ -115,7 +162,9 @@ export default function DeadlineForm(props: Props) {
         setGlobalError(data.error ?? "この操作は許可されていません。");
         setStatus("error");
       } else {
-        setGlobalError(data.error ?? "保存に失敗しました。もう一度お試しください。");
+        setGlobalError(
+          data.error ?? "保存に失敗しました。もう一度お試しください。",
+        );
         setStatus("error");
       }
     } catch {
@@ -128,32 +177,33 @@ export default function DeadlineForm(props: Props) {
   const isLimitExceeded = status === "limit_exceeded";
 
   return (
-    <form onSubmit={handleSubmit} noValidate className="mt-8 space-y-5">
-      {/* Free 枠上限エラー（create モードのみ） */}
+    <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-6">
+      {/* Free 枠上限エラー */}
       {isLimitExceeded && (
         <div
           role="alert"
-          className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+          className="rounded-[var(--radius-card)] border border-[var(--u-soon-bg)] bg-[var(--u-soon-bg)] px-4 py-3 text-sm text-[var(--u-soon)]"
         >
-          <p className="font-semibold">Free プランの登録上限（10件）に達しました</p>
+          <p className="font-semibold">
+            Free プランの登録上限（10件）に達しました
+          </p>
           <p className="mt-1">
-            Pro にアップグレードすると締切アイテムが{" "}
-            <strong>無制限</strong>になります。
+            Pro にアップグレードすると締切アイテムが<strong>無制限</strong>
+            になります。
           </p>
           <Link
             href="/billing"
-            className="mt-2 inline-block rounded-md bg-amber-600 px-4 py-1.5 text-sm font-semibold text-white hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-1"
+            className="mt-2 inline-block rounded-xl bg-[var(--u-soon)] px-4 py-1.5 text-sm font-semibold text-white hover:opacity-90"
           >
             Pro にアップグレード →
           </Link>
         </div>
       )}
 
-      {/* グローバルエラー */}
       {globalError && (
         <p
           role="alert"
-          className="rounded-lg bg-red-50 px-4 py-2 text-sm text-red-700"
+          className="rounded-xl bg-[var(--u-overdue-bg)] px-4 py-2 text-sm text-[var(--u-overdue)]"
         >
           {globalError}
         </p>
@@ -163,10 +213,10 @@ export default function DeadlineForm(props: Props) {
       <div>
         <label
           htmlFor="company_name"
-          className="block text-sm font-medium text-slate-700"
+          className="block text-sm font-semibold text-[var(--ink-2)]"
         >
           企業名
-          <span className="ml-1 text-red-500">*</span>
+          <span className="ml-1 text-[var(--u-overdue)]">*</span>
         </label>
         <input
           id="company_name"
@@ -176,65 +226,78 @@ export default function DeadlineForm(props: Props) {
           placeholder="例: 株式会社テクノロジー"
           maxLength={100}
           disabled={isSubmitting}
-          className={`mt-1 w-full rounded-lg border px-3 py-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 ${
+          className={`mt-2 w-full rounded-xl border px-4 py-3 text-sm outline-none transition-colors focus:border-brand focus:ring-2 focus:ring-brand/20 disabled:opacity-50 ${
             fieldErrors.company_name
-              ? "border-red-400 bg-red-50"
-              : "border-slate-300 bg-white"
+              ? "border-[var(--u-overdue)] bg-[var(--u-overdue-bg)]"
+              : "border-[var(--rule)] bg-[var(--card)]"
           }`}
         />
         <AnimatePresence>
           {fieldErrors.company_name && (
-            <motion.p {...scaleIn} role="alert" className="mt-1 text-xs text-red-600">
+            <motion.p
+              {...scaleIn}
+              role="alert"
+              className="mt-1 text-xs text-[var(--u-overdue)]"
+            >
               {fieldErrors.company_name}
             </motion.p>
           )}
         </AnimatePresence>
       </div>
 
-      {/* 種別 */}
+      {/* 種別タイル */}
       <div>
-        <label
-          htmlFor="kind"
-          className="block text-sm font-medium text-slate-700"
-        >
+        <p className="text-sm font-semibold text-[var(--ink-2)]">
           種別
-          <span className="ml-1 text-red-500">*</span>
-        </label>
-        <select
-          id="kind"
-          value={kind}
-          onChange={(e) => setKind(e.target.value)}
-          disabled={isSubmitting}
-          className={`mt-1 w-full rounded-lg border px-3 py-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 ${
-            fieldErrors.kind
-              ? "border-red-400 bg-red-50"
-              : "border-slate-300 bg-white"
-          }`}
-        >
-          <option value="">選択してください</option>
-          {KIND_OPTIONS.map(([value, label]) => (
-            <option key={value} value={value}>
-              {label}
-            </option>
+          <span className="ml-1 text-[var(--u-overdue)]">*</span>
+        </p>
+        <div className="mt-2 grid grid-cols-2 gap-3">
+          {KIND_TILES.map(({ value, label, icon, desc }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setKind(value)}
+              disabled={isSubmitting}
+              className={`relative rounded-[var(--radius-card)] border-2 p-4 text-left transition-all disabled:opacity-50 ${
+                kind === value
+                  ? "border-brand bg-brand/5"
+                  : "border-[var(--rule)] bg-[var(--card)] hover:border-brand/40"
+              }`}
+            >
+              {kind === value && (
+                <span className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-brand text-[10px] font-bold text-white">
+                  ✓
+                </span>
+              )}
+              <span className="text-2xl">{icon}</span>
+              <p className="mt-1.5 text-sm font-semibold text-[var(--ink)]">
+                {label}
+              </p>
+              <p className="text-xs text-[var(--ink-3)]">{desc}</p>
+            </button>
           ))}
-        </select>
+        </div>
         <AnimatePresence>
           {fieldErrors.kind && (
-            <motion.p {...scaleIn} role="alert" className="mt-1 text-xs text-red-600">
+            <motion.p
+              {...scaleIn}
+              role="alert"
+              className="mt-1 text-xs text-[var(--u-overdue)]"
+            >
               {fieldErrors.kind}
             </motion.p>
           )}
         </AnimatePresence>
       </div>
 
-      {/* 締切日時 */}
+      {/* 締切日時 + クイック選択 */}
       <div>
         <label
           htmlFor="deadline_at"
-          className="block text-sm font-medium text-slate-700"
+          className="block text-sm font-semibold text-[var(--ink-2)]"
         >
           締切日時
-          <span className="ml-1 text-red-500">*</span>
+          <span className="ml-1 text-[var(--u-overdue)]">*</span>
         </label>
         <input
           id="deadline_at"
@@ -242,15 +305,33 @@ export default function DeadlineForm(props: Props) {
           value={deadlineAt}
           onChange={(e) => setDeadlineAt(e.target.value)}
           disabled={isSubmitting}
-          className={`mt-1 w-full rounded-lg border px-3 py-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 ${
+          className={`mt-2 w-full rounded-xl border px-4 py-3 text-sm outline-none transition-colors focus:border-brand focus:ring-2 focus:ring-brand/20 disabled:opacity-50 ${
             fieldErrors.deadline_at
-              ? "border-red-400 bg-red-50"
-              : "border-slate-300 bg-white"
+              ? "border-[var(--u-overdue)] bg-[var(--u-overdue-bg)]"
+              : "border-[var(--rule)] bg-[var(--card)]"
           }`}
         />
+        {/* クイック時間チップ */}
+        <div className="mt-2 flex flex-wrap gap-2">
+          {QUICK_TIMES.map(({ label, getDate }) => (
+            <button
+              key={label}
+              type="button"
+              onClick={() => setDeadlineAt(toDatetimeLocal(getDate()))}
+              disabled={isSubmitting}
+              className="rounded-full bg-[var(--paper-2)] px-3 py-1 text-xs font-semibold text-[var(--ink-2)] hover:bg-brand/10 hover:text-brand disabled:opacity-50"
+            >
+              {label}
+            </button>
+          ))}
+        </div>
         <AnimatePresence>
           {fieldErrors.deadline_at && (
-            <motion.p {...scaleIn} role="alert" className="mt-1 text-xs text-red-600">
+            <motion.p
+              {...scaleIn}
+              role="alert"
+              className="mt-1 text-xs text-[var(--u-overdue)]"
+            >
               {fieldErrors.deadline_at}
             </motion.p>
           )}
@@ -261,10 +342,12 @@ export default function DeadlineForm(props: Props) {
       <div>
         <label
           htmlFor="link"
-          className="block text-sm font-medium text-slate-700"
+          className="block text-sm font-semibold text-[var(--ink-2)]"
         >
           リンク
-          <span className="ml-1 text-xs text-slate-400">（任意）</span>
+          <span className="ml-1 text-xs font-normal text-[var(--ink-4)]">
+            （任意）
+          </span>
         </label>
         <input
           id="link"
@@ -274,29 +357,24 @@ export default function DeadlineForm(props: Props) {
           placeholder="https://example.com/job"
           maxLength={2048}
           disabled={isSubmitting}
-          className={`mt-1 w-full rounded-lg border px-3 py-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 ${
+          className={`mt-2 w-full rounded-xl border px-4 py-3 text-sm outline-none transition-colors focus:border-brand focus:ring-2 focus:ring-brand/20 disabled:opacity-50 ${
             fieldErrors.link
-              ? "border-red-400 bg-red-50"
-              : "border-slate-300 bg-white"
+              ? "border-[var(--u-overdue)] bg-[var(--u-overdue-bg)]"
+              : "border-[var(--rule)] bg-[var(--card)]"
           }`}
         />
-        <AnimatePresence>
-          {fieldErrors.link && (
-            <motion.p {...scaleIn} role="alert" className="mt-1 text-xs text-red-600">
-              {fieldErrors.link}
-            </motion.p>
-          )}
-        </AnimatePresence>
       </div>
 
       {/* メモ（任意） */}
       <div>
         <label
           htmlFor="memo"
-          className="block text-sm font-medium text-slate-700"
+          className="block text-sm font-semibold text-[var(--ink-2)]"
         >
           メモ
-          <span className="ml-1 text-xs text-slate-400">（任意）</span>
+          <span className="ml-1 text-xs font-normal text-[var(--ink-4)]">
+            （任意）
+          </span>
         </label>
         <textarea
           id="memo"
@@ -306,42 +384,54 @@ export default function DeadlineForm(props: Props) {
           maxLength={1000}
           rows={3}
           disabled={isSubmitting}
-          className={`mt-1 w-full rounded-lg border px-3 py-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 ${
+          className={`mt-2 w-full rounded-xl border px-4 py-3 text-sm outline-none transition-colors focus:border-brand focus:ring-2 focus:ring-brand/20 disabled:opacity-50 ${
             fieldErrors.memo
-              ? "border-red-400 bg-red-50"
-              : "border-slate-300 bg-white"
+              ? "border-[var(--u-overdue)] bg-[var(--u-overdue-bg)]"
+              : "border-[var(--rule)] bg-[var(--card)]"
           }`}
         />
-        <AnimatePresence>
-          {fieldErrors.memo && (
-            <motion.p {...scaleIn} role="alert" className="mt-1 text-xs text-red-600">
-              {fieldErrors.memo}
-            </motion.p>
-          )}
-        </AnimatePresence>
       </div>
 
-      {/* 送信ボタン */}
-      <div className="flex items-center gap-4">
-        <button
-          type="submit"
-          disabled={isSubmitting || isLimitExceeded}
-          className="rounded-lg bg-indigo-600 px-6 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          {isSubmitting
-            ? "保存中..."
-            : isLimitExceeded
-              ? "上限に達しています"
-              : props.mode === "edit"
-                ? "保存する"
-                : "作成する"}
-        </button>
-        <Link
-          href="/dashboard"
-          className="text-sm text-slate-500 underline hover:text-slate-700"
-        >
-          キャンセル
-        </Link>
+      {/* 通知スケジュールプレビュー */}
+      <div className="rounded-[var(--radius-card)] border border-[var(--rule)] bg-[var(--paper)] p-4">
+        <p className="text-xs font-semibold uppercase tracking-widest text-[var(--ink-3)]">
+          通知スケジュール
+        </p>
+        <div className="mt-3 space-y-2">
+          {["72時間前", "24時間前", "3時間前"].map((label) => (
+            <div key={label} className="flex items-center gap-2">
+              <div className="h-1.5 w-1.5 rounded-full bg-brand" />
+              <span className="text-sm text-[var(--ink-2)]">
+                {label}にメール通知
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* スティッキー保存バー */}
+      <div className="sticky bottom-0 -mx-6 border-t border-[var(--rule)] bg-[var(--paper)]/95 px-6 py-4 backdrop-blur-sm">
+        <div className="flex items-center gap-4">
+          <button
+            type="submit"
+            disabled={isSubmitting || isLimitExceeded}
+            className="flex-1 rounded-xl bg-brand py-3 text-sm font-semibold text-white hover:bg-brand-hover disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isSubmitting
+              ? "保存中…"
+              : isLimitExceeded
+                ? "上限に達しています"
+                : props.mode === "edit"
+                  ? "保存する"
+                  : "作成する"}
+          </button>
+          <Link
+            href="/dashboard"
+            className="text-sm text-[var(--ink-3)] hover:text-[var(--ink-2)]"
+          >
+            キャンセル
+          </Link>
+        </div>
       </div>
     </form>
   );

--- a/src/app/deadline/new/page.tsx
+++ b/src/app/deadline/new/page.tsx
@@ -1,13 +1,37 @@
+import Link from "next/link";
 import DeadlineForm from "./DeadlineForm";
 
 export default function NewDeadlinePage() {
   return (
-    <main className="mx-auto max-w-2xl p-6">
-      <h1 className="text-2xl font-bold">締切の新規作成</h1>
-      <p className="mt-1 text-sm text-slate-500">
-        <span className="text-red-500">*</span> は必須項目です
-      </p>
-      <DeadlineForm mode="create" />
+    <main className="mx-auto max-w-xl px-6 pb-24 pt-6">
+      {/* ページヘッダー */}
+      <div className="flex items-center gap-3">
+        <Link
+          href="/dashboard"
+          className="rounded-lg p-1.5 text-[var(--ink-3)] hover:bg-[var(--paper-2)]"
+          aria-label="ダッシュボードに戻る"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+        </Link>
+        <h1 className="text-xl font-bold text-[var(--ink)]">締切を登録する</h1>
+      </div>
+
+      <div className="mt-6">
+        <DeadlineForm mode="create" />
+      </div>
     </main>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,14 +8,125 @@
 @import "@fontsource/inter/900.css";
 @import "@fontsource/noto-sans-jp/400.css";
 @import "@fontsource/noto-sans-jp/700.css";
+@import "@fontsource/jetbrains-mono/400.css";
+@import "@fontsource/jetbrains-mono/600.css";
 
+/* ─── Design Tokens ─────────────────────────────────────── */
 :root {
   color-scheme: light;
+
+  /* Surface */
+  --paper:   #f7f5f0;
+  --paper-2: #ede9df;
+  --card:    #ffffff;
+
+  /* Ink (text hierarchy) */
+  --ink:   #0f0d1a;
+  --ink-2: #2c2740;
+  --ink-3: #6b6580;
+  --ink-4: #9a93ad;
+
+  /* Rule */
+  --rule: rgba(15, 13, 26, 0.08);
+
+  /* Brand */
+  --brand:     #4f46e5;
+  --brand-600: #4338ca;
+  --brand-50:  #eef2ff;
+  --brand-100: #e0e7ff;
+
+  /* Urgency */
+  --u-overdue:    #d23a3a;
+  --u-overdue-bg: #fdecec;
+  --u-today:      #e9651c;
+  --u-today-bg:   #fff1e8;
+  --u-soon:       #b0871f;
+  --u-soon-bg:    #fff7da;
+  --u-normal:     #4f46e5;
+  --u-normal-bg:  #eef2ff;
+
+  /* Status */
+  --s-done:    #1f8a5b;
+  --s-done-bg: #e6f5ed;
+
+  /* Radius */
+  --radius-card: 18px;
+
+  /* Shadow */
+  --shadow-card: 0 4px 16px rgba(15, 13, 26, 0.08);
+  --shadow-pop:  0 8px 32px rgba(15, 13, 26, 0.14);
 }
 
+/* ─── Dark theme ────────────────────────────────────────── */
+[data-theme="ink"] {
+  color-scheme: dark;
+  --paper:   #131220;
+  --paper-2: #1a1830;
+  --card:    #1f1d33;
+  --ink:     #f6f4ff;
+  --ink-2:   #d4d0f0;
+  --ink-3:   #8b86b0;
+  --ink-4:   #5a5680;
+  --rule:    rgba(246, 244, 255, 0.08);
+}
+
+/* ─── Base styles ───────────────────────────────────────── */
 body {
-  @apply bg-white text-gray-900;
+  background-color: var(--paper);
+  color: var(--ink);
   font-family: "Inter", "Noto Sans JP", sans-serif;
+  font-feature-settings: "ss01", "cv11";
+  letter-spacing: -0.01em;
+}
+
+/* ─── Kind tag colors ───────────────────────────────────── */
+.kind-es        { background: #e9defb; color: #5b3a93; }
+.kind-briefing  { background: #d8eef0; color: #1f6168; }
+.kind-interview { background: #fde0c8; color: #a04316; }
+.kind-other     { background: var(--paper-2); color: var(--ink-2); }
+
+/* ─── Motion ────────────────────────────────────────────── */
+@keyframes wiggle {
+  0%, 100% { transform: rotate(-3deg); }
+  25%       { transform: rotate(2deg); }
+  50%       { transform: rotate(-1deg); }
+  75%       { transform: rotate(3deg); }
+}
+
+@keyframes pop-in {
+  0%   { opacity: 0; transform: scale(0.85); }
+  60%  { opacity: 1; transform: scale(1.05); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+@keyframes slide-in-down {
+  from { opacity: 0; transform: translateY(-12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes draw-prog {
+  from { transform: scaleX(0); }
+  to   { transform: scaleX(var(--p, 1)); }
+}
+
+@keyframes ring-fill {
+  from { stroke-dashoffset: var(--ring-from, 138); }
+  to   { stroke-dashoffset: var(--ring-to, 0); }
+}
+
+@keyframes pulse-dot {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50%       { transform: scale(1.05); opacity: 0.85; }
+}
+
+/* Tailwind 既存のアニメーション */
+@keyframes fade-up {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes scale-in {
+  from { opacity: 0; transform: scale(0.95); }
+  to   { opacity: 1; transform: scale(1); }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -78,20 +78,28 @@ export default function LoginForm() {
           <div>
             <label
               htmlFor="email"
-              className="block text-sm font-medium text-slate-700"
+              className="block text-sm font-medium text-[var(--ink-2)]"
             >
               メールアドレス
             </label>
-            <input
-              id="email"
-              type="email"
-              required
-              autoFocus
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="you@example.com"
-              className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-3 text-sm outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500"
-            />
+            <div className="relative mt-1">
+              <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-[var(--ink-3)]">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <rect width="20" height="16" x="2" y="4" rx="2" />
+                  <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+                </svg>
+              </span>
+              <input
+                id="email"
+                type="email"
+                required
+                autoFocus
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+                className="block w-full rounded-lg border border-[var(--rule)] bg-white pl-9 pr-3 py-3 text-sm text-[var(--ink)] placeholder:text-[var(--ink-4)] outline-none focus:border-brand focus:ring-2 focus:ring-brand/20"
+              />
+            </div>
           </div>
 
           {status === "error" && (
@@ -103,7 +111,7 @@ export default function LoginForm() {
           <button
             type="submit"
             disabled={status === "loading"}
-            className="w-full rounded-lg bg-indigo-600 px-4 py-3 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-60"
+            className="w-full rounded-lg bg-[var(--ink)] px-4 py-3 text-sm font-semibold text-white hover:bg-brand transition-colors disabled:opacity-60"
           >
             {status === "loading" ? "送信中…" : "マジックリンクを送信"}
           </button>

--- a/src/app/login/_components/NotificationToast.tsx
+++ b/src/app/login/_components/NotificationToast.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function NotificationToast() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(true), 600);
+    return () => clearTimeout(t);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      style={{ animation: "slide-in-down 0.35s ease both" }}
+      className="flex items-center gap-3 rounded-2xl bg-white px-4 py-3 shadow-lg shadow-black/10"
+    >
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-brand text-white text-lg font-black">
+        〆
+      </div>
+      <div className="min-w-0">
+        <p className="text-xs font-semibold text-[var(--ink-3)]">〆トラ</p>
+        <p className="text-sm font-medium text-[var(--ink)] truncate">
+          ⏰ 明日 9:00 締切 — 〇〇商事 ES
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,28 +1,50 @@
 import { Suspense } from "react";
 import LoginForm from "./LoginForm";
+import { NotificationToast } from "./_components/NotificationToast";
 
 export const metadata = {
   title: "ログイン | 〆トラ",
 };
 
+function SealLogo() {
+  return (
+    <div
+      style={{ animation: "wiggle 2s ease-in-out infinite" }}
+      className="mx-auto flex h-20 w-20 items-center justify-center rounded-2xl bg-brand text-4xl font-black text-white shadow-lg shadow-brand/30"
+    >
+      〆
+    </div>
+  );
+}
+
 export default function LoginPage() {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-sm rounded-2xl border border-gray-200 bg-white p-8 shadow-lg">
-        <div className="mb-6 text-center">
-          <p className="text-2xl font-black tracking-tight text-indigo-600">〆トラ</p>
-          <p className="mt-0.5 text-xs text-gray-400">就活の締切を、逃さない。</p>
+    <main className="min-h-screen bg-[var(--paper)] flex flex-col items-center justify-center px-4 py-12">
+      <div className="w-full max-w-sm space-y-8">
+        {/* 〆印章ロゴ＋キャッチコピー＋通知トースト */}
+        <div className="text-center space-y-4">
+          <SealLogo />
+          <h1 className="text-2xl font-black tracking-tight text-[var(--ink)]">
+            締切を、出し忘れない人生に。
+          </h1>
+          {/* useSearchParams を使う LoginForm は Suspense で囲む */}
+          <Suspense>
+            <NotificationToast />
+          </Suspense>
         </div>
-        <h1 className="text-lg font-bold text-gray-900">
-          ログイン / サインアップ
-        </h1>
-        <p className="mt-1 text-sm text-gray-500">
-          メールアドレスを入力するとログインリンクを送ります。
-        </p>
-        {/* useSearchParams を使う LoginForm は Suspense で囲む */}
-        <Suspense>
-          <LoginForm />
-        </Suspense>
+
+        {/* ログインフォーム */}
+        <div className="rounded-2xl border border-[var(--rule)] bg-white p-8 shadow-sm">
+          <h2 className="text-lg font-bold text-[var(--ink)]">
+            ログイン / サインアップ
+          </h2>
+          <p className="mt-1 text-sm text-[var(--ink-3)]">
+            メールアドレスを入力するとログインリンクを送ります。
+          </p>
+          <Suspense>
+            <LoginForm />
+          </Suspense>
+        </div>
       </div>
     </main>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,9 +13,25 @@ const config: Config = {
           light: "#eef2ff",
           hover: "#4338ca",
         },
+        ink: "#0f0d1a",
+        paper: "#f7f5f0",
+        urgency: {
+          overdue: "#d23a3a",
+          "overdue-bg": "#fdecec",
+          today: "#e9651c",
+          "today-bg": "#fff1e8",
+          soon: "#b0871f",
+          "soon-bg": "#fff7da",
+        },
+        kind: {
+          es: { bg: "#e9defb", text: "#5b3a93" },
+          briefing: { bg: "#d8eef0", text: "#1f6168" },
+          interview: { bg: "#fde0c8", text: "#a04316" },
+        },
       },
       fontFamily: {
         sans: ["Inter", "Noto Sans JP", "sans-serif"],
+        mono: ["JetBrains Mono", "monospace"],
       },
       keyframes: {
         "fade-up": {


### PR DESCRIPTION
## Summary

デザインファイル（shimetra-redesign/index.html）との差分を全て実装した統合 PR。

### 含まれる変更

| PR | 内容 |
|---|---|
| #181 | デザイントークン基盤（CSS変数 + JetBrains Mono） |
| #183 | ログインページ（〆印章ロゴ + iOS通知トースト） |
| #185 | ダッシュボード（HeroCard + UrgencyRing + フィルターチップ + FAB） |
| #187 | フォーム（種別タイル + クイック時間チップ + 通知プレビュー + スティッキー保存バー） |
| #189 | AppHeader（backdrop-blur + 分割ロゴ） |

### 主な変更点

- `globals.css`: CSS変数システム（--paper, --ink, --card, --rule, urgency, status, kind）
- `tailwind.config.ts`: brand/urgency/kind カラートークン
- `login/page.tsx`: 〆印章ロゴ（wiggle アニメ）+ キャッチコピー
- `login/_components/NotificationToast.tsx`: iOS風通知トースト（600ms delay）
- `dashboard/HeroCard.tsx`: 次の締切カウントダウン + グリーティング
- `dashboard/UrgencyRing.tsx`: SVG 52×52 円形プログレス
- `dashboard/DeadlineList.tsx`: フィルターチップ・FAB・種別タグカラー・ステータスピル循環
- `deadline/new/DeadlineForm.tsx`: 種別タイル + クイック時間 + 通知プレビュー
- `_components/AppHeader.tsx`: sticky + backdrop-blur + 分割ロゴ

## Test plan

- [x] `npx tsc --noEmit` — 型エラーなし（統合ブランチ含む）
- [ ] ブラウザ確認: `/login` `/dashboard` `/deadline/new` の全ページ

Closes #180
Closes #182
Closes #184
Closes #186
Closes #188