### PR TITLE
design: shimetra-redesign の UI/UX を徹底的に実装する

### DIFF
--- a/src/app/_components/AppHeader.tsx
+++ b/src/app/_components/AppHeader.tsx
@@ -2,8 +2,6 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { motion } from "framer-motion";
-import { fadeUp } from "@/lib/motion";
 
 interface AppHeaderProps {
   email: string;
@@ -11,7 +9,6 @@ interface AppHeaderProps {
 
 export function AppHeader({ email }: AppHeaderProps) {
   const router = useRouter();
-  const displayEmail = email.length > 20 ? email.slice(0, 20) + "…" : email;
 
   async function handleLogout() {
     await fetch("/api/auth/logout", { method: "POST" });
@@ -19,35 +16,104 @@ export function AppHeader({ email }: AppHeaderProps) {
   }
 
   return (
-    <motion.header
-      className="sticky top-0 z-20 border-b border-[var(--rule)] bg-[var(--paper)]/90 backdrop-blur-md"
-      initial={fadeUp.initial}
-      animate={fadeUp.animate}
-      transition={fadeUp.transition}
+    <header
+      className="sticky top-0 z-30 border-b border-[var(--rule)]"
+      style={{
+        background: "color-mix(in oklab, var(--paper) 88%, transparent)",
+        backdropFilter: "blur(10px)",
+      }}
     >
-      <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-3">
+      <div className="mx-auto flex max-w-4xl items-center justify-between px-5 py-2.5">
+        {/* ブランドマーク */}
         <Link
           href="/dashboard"
-          className="flex items-center gap-0.5 transition-opacity hover:opacity-80"
+          className="flex items-center gap-2 text-[var(--ink)] hover:opacity-80 transition-opacity"
+          style={{ fontWeight: 800, letterSpacing: "-0.02em" }}
         >
-          <span className="text-lg font-black text-brand">〆</span>
-          <span className="text-lg font-black text-[var(--ink)]">トラ</span>
-        </Link>
-        <div className="flex items-center gap-3">
           <span
-            className="hidden text-sm text-[var(--ink-3)] sm:block"
-            title={email}
+            className="brand-seal relative inline-flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-[8px] bg-[var(--ink)] text-white"
+            style={{
+              fontFamily: '"Noto Sans JP", serif',
+              fontWeight: 900,
+              fontSize: 18,
+              transform: "rotate(-4deg)",
+            }}
+            aria-hidden="true"
           >
-            {displayEmail}
+            〆
           </span>
+          <span style={{ fontSize: 17 }}>トラ</span>
+        </Link>
+
+        {/* 右側アイコンボタン群 */}
+        <div className="flex items-center gap-1.5">
+          {/* 検索 */}
+          <button
+            className="relative inline-flex h-[38px] w-[38px] items-center justify-center rounded-[12px] border border-[var(--rule)] bg-[var(--card)] text-[var(--ink-2)] transition-all hover:-translate-y-px hover:border-[var(--ink-3)] hover:text-[var(--ink)]"
+            aria-label="検索"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.35-4.35" />
+            </svg>
+          </button>
+
+          {/* 通知ベル */}
+          <button
+            className="relative inline-flex h-[38px] w-[38px] items-center justify-center rounded-[12px] border border-[var(--rule)] bg-[var(--card)] text-[var(--ink-2)] transition-all hover:-translate-y-px hover:border-[var(--ink-3)] hover:text-[var(--ink)]"
+            aria-label="通知"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+              <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+            </svg>
+          </button>
+
+          {/* ログアウト */}
           <button
             onClick={handleLogout}
-            className="rounded-lg border border-[var(--rule)] px-4 py-2 text-sm font-medium text-[var(--ink-2)] transition-colors hover:bg-[var(--paper-2)]"
+            className="relative inline-flex h-[38px] w-[38px] items-center justify-center rounded-[12px] border border-[var(--rule)] bg-[var(--card)] text-[var(--ink-2)] transition-all hover:-translate-y-px hover:border-[var(--ink-3)] hover:text-[var(--ink)]"
+            aria-label={`ログアウト (${email})`}
+            title={`ログアウト（${email}）`}
           >
-            ログアウト
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+              <polyline points="16 17 21 12 16 7" />
+              <line x1="21" y1="12" x2="9" y2="12" />
+            </svg>
           </button>
         </div>
       </div>
-    </motion.header>
+    </header>
   );
 }

--- a/src/app/_components/HomePageClient.tsx
+++ b/src/app/_components/HomePageClient.tsx
@@ -2,19 +2,51 @@
 
 import Link from "next/link";
 import { motion } from "framer-motion";
-import { fadeUp, stagger } from "@/lib/motion";
+import { fadeUp } from "@/lib/motion";
 import { FREE_FEATURES, PRO_FEATURES } from "@/config/plans";
+
+const PROBLEMS = [
+  { icon: "📭", text: "気づいたら締切が過ぎていた" },
+  { icon: "🗂️", text: "複数企業の締切を覚えきれない" },
+  { icon: "😓", text: "Notion に書いたが更新が止まった" },
+];
+
+const HOW_STEPS = [
+  { num: "01", title: "締切を登録する", desc: "企業名・種別・締切日時をサッと入力。リンクやメモも保存できます。" },
+  { num: "02", title: "通知が届く", desc: "締切の 72時間前・24時間前・3時間前にメールで通知します。" },
+  { num: "03", title: "出し忘れゼロへ", desc: "通知を受け取り、ステータスを更新。就活の締切を確実に守れます。" },
+];
 
 export function HomePageClient() {
   return (
-    <div className="min-h-screen bg-white font-sans">
-      {/* ナビゲーション */}
-      <header className="sticky top-0 z-10 border-b border-gray-100 bg-white/90 backdrop-blur-sm">
-        <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
-          <span className="text-xl font-black tracking-tight text-indigo-600">〆トラ</span>
+    <div className="min-h-screen bg-[var(--paper)] font-sans">
+      {/* ── ナビゲーション ── */}
+      <header
+        className="sticky top-0 z-10 border-b border-[var(--rule)]"
+        style={{
+          background: "color-mix(in oklab, var(--paper) 92%, transparent)",
+          backdropFilter: "blur(10px)",
+        }}
+      >
+        <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-3">
+          <div className="flex items-center gap-2" style={{ fontWeight: 800, letterSpacing: "-0.02em" }}>
+            <span
+              className="brand-seal relative inline-flex h-[28px] w-[28px] items-center justify-center rounded-[8px] bg-[var(--ink)] text-white"
+              style={{
+                fontFamily: '"Noto Sans JP", serif',
+                fontWeight: 900,
+                fontSize: 16,
+                transform: "rotate(-4deg)",
+              }}
+              aria-hidden="true"
+            >
+              〆
+            </span>
+            <span className="text-[16px] text-[var(--ink)]">トラ</span>
+          </div>
           <Link
             href="/login"
-            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
+            className="rounded-[10px] bg-[var(--ink)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand"
           >
             ログイン / 無料登録
           </Link>
@@ -22,125 +54,247 @@ export function HomePageClient() {
       </header>
 
       <main>
-        {/* Hero */}
-        <motion.section
-          variants={stagger}
-          initial="initial"
-          animate="animate"
-          className="mx-auto max-w-4xl px-6 py-24 text-center"
-        >
-          <motion.h1
-            variants={fadeUp}
-            className="text-5xl font-black tracking-tighter text-gray-900 sm:text-7xl"
-          >
-            締切ミスを、
-            <br />
-            <span className="text-indigo-600">もうしない。</span>
-          </motion.h1>
-          <motion.p
-            variants={fadeUp}
-            className="mx-auto mt-6 max-w-xl text-lg text-gray-600"
-          >
-            ES・説明会・面接の締切を一元管理し、
-            <br className="hidden sm:block" />
-            締切前にメールで通知。就活の出し忘れを防ぎます。
-          </motion.p>
-          <motion.div variants={fadeUp} className="mt-10 flex justify-center gap-4">
-            <Link
-              href="/login"
-              className="rounded-xl bg-indigo-600 px-8 py-3 text-base font-semibold text-white shadow-lg shadow-indigo-200 hover:bg-indigo-700"
+        {/* ── Hero ── */}
+        <section className="mx-auto max-w-5xl px-6 py-20 lg:py-28">
+          <div className="lg:grid lg:grid-cols-2 lg:gap-16 lg:items-center">
+            {/* 左: テキスト */}
+            <motion.div
+              initial={fadeUp.initial}
+              animate={fadeUp.animate}
+              transition={fadeUp.transition}
+              className="stagger"
             >
-              無料ではじめる
-            </Link>
-          </motion.div>
-          <motion.p variants={fadeUp} className="mt-4 text-sm text-gray-400">
-            クレジットカード不要 · 10件まで無料
-          </motion.p>
-        </motion.section>
+              {/* 大きなシール */}
+              <div
+                className="big-seal relative mb-8 inline-flex h-[80px] w-[80px] items-center justify-center rounded-[20px] bg-[var(--ink)] text-white lg:h-[96px] lg:w-[96px] lg:rounded-[24px]"
+                style={{
+                  fontFamily: '"Noto Sans JP", serif',
+                  fontWeight: 900,
+                  fontSize: 48,
+                  letterSpacing: "-0.04em",
+                  transform: "rotate(-3deg)",
+                }}
+              >
+                〆
+              </div>
 
-        {/* Problem */}
-        <section className="bg-gray-50 py-20">
+              <h1
+                className="text-[40px] font-black text-[var(--ink)] leading-tight sm:text-[52px] lg:text-[56px]"
+                style={{ letterSpacing: "-0.035em" }}
+              >
+                締切ミスを、<br />
+                <span style={{ color: "var(--brand)" }}>もうしない。</span>
+              </h1>
+              <p className="mt-5 max-w-md text-[var(--ink-2)] leading-relaxed lg:text-lg">
+                ES・説明会・面接の締切を一元管理。<br />
+                締切前にメールで通知し、就活の出し忘れを防ぎます。
+              </p>
+
+              <div className="mt-8 flex flex-wrap gap-3">
+                <Link
+                  href="/login"
+                  className="rounded-[14px] bg-[var(--ink)] px-7 py-3.5 text-base font-bold text-[var(--paper)] transition-all hover:bg-brand hover:-translate-y-px"
+                  style={{ boxShadow: "0 8px 24px -8px rgba(15,13,26,0.4)" }}
+                >
+                  無料ではじめる
+                </Link>
+                <Link
+                  href="/login"
+                  className="rounded-[14px] border border-[var(--rule)] bg-[var(--card)] px-7 py-3.5 text-base font-semibold text-[var(--ink-2)] transition-all hover:border-[var(--ink-3)] hover:-translate-y-px"
+                >
+                  ログインする
+                </Link>
+              </div>
+              <p className="mt-4 text-sm text-[var(--ink-4)]">
+                クレジットカード不要 · 10件まで無料
+              </p>
+            </motion.div>
+
+            {/* 右: アプリプレビュー（デスクトップのみ） */}
+            <div className="hidden lg:block">
+              <AppPreview />
+            </div>
+          </div>
+        </section>
+
+        {/* ── こんな経験 ── */}
+        <section
+          className="border-y border-[var(--rule)] py-16 lg:py-20"
+          style={{ background: "var(--paper-2)" }}
+        >
           <motion.div
             initial={fadeUp.initial}
             whileInView={fadeUp.animate}
             viewport={{ once: true, margin: "-80px" }}
             transition={fadeUp.transition}
-            className="mx-auto max-w-4xl px-6"
+            className="mx-auto max-w-5xl px-6"
           >
-            <h2 className="text-center text-3xl font-bold text-gray-900">
+            <p
+              className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--ink-4)] text-center"
+            >
+              THE PROBLEM
+            </p>
+            <h2
+              className="mt-3 text-center text-[28px] font-black text-[var(--ink)] lg:text-[34px]"
+              style={{ letterSpacing: "-0.025em" }}
+            >
               こんな経験、ありませんか？
             </h2>
-            <ul className="mx-auto mt-8 max-w-md space-y-4 text-gray-700">
-              {[
-                "気づいたら締切が過ぎていた",
-                "複数の企業の締切を覚えきれない",
-                "Notionに書いたけど更新が止まった",
-              ].map((item) => (
-                <li key={item} className="flex items-start gap-3 text-base">
-                  <span className="mt-0.5 font-bold text-red-500">✕</span>
-                  <span>{item}</span>
-                </li>
+            <div className="mt-10 grid gap-4 sm:grid-cols-3">
+              {PROBLEMS.map(({ icon, text }) => (
+                <div
+                  key={text}
+                  className="rounded-[var(--radius-card)] border border-[var(--rule)] bg-[var(--card)] px-5 py-5 shadow-[var(--shadow-card)]"
+                >
+                  <span className="text-3xl">{icon}</span>
+                  <p className="mt-3 font-semibold text-[var(--ink)] leading-snug">{text}</p>
+                </div>
               ))}
-            </ul>
+            </div>
           </motion.div>
         </section>
 
-        {/* Pricing */}
-        <section className="mx-auto max-w-4xl px-6 py-24">
+        {/* ── 使い方 ── */}
+        <section className="py-16 lg:py-24">
           <motion.div
             initial={fadeUp.initial}
             whileInView={fadeUp.animate}
             viewport={{ once: true, margin: "-80px" }}
             transition={fadeUp.transition}
+            className="mx-auto max-w-5xl px-6"
           >
-            <h2 className="text-center text-3xl font-bold text-gray-900">
+            <p
+              className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--ink-4)] text-center"
+            >
+              HOW IT WORKS
+            </p>
+            <h2
+              className="mt-3 text-center text-[28px] font-black text-[var(--ink)] lg:text-[34px]"
+              style={{ letterSpacing: "-0.025em" }}
+            >
+              3ステップで使い始める
+            </h2>
+            <div className="mt-10 grid gap-6 sm:grid-cols-3">
+              {HOW_STEPS.map(({ num, title, desc }) => (
+                <div key={num} className="flex flex-col gap-3">
+                  <span
+                    className="font-mono text-[32px] font-black text-[var(--ink-4)]"
+                    style={{ letterSpacing: "-0.04em" }}
+                  >
+                    {num}
+                  </span>
+                  <h3 className="text-base font-bold text-[var(--ink)]">{title}</h3>
+                  <p className="text-sm text-[var(--ink-3)] leading-relaxed">{desc}</p>
+                </div>
+              ))}
+            </div>
+          </motion.div>
+        </section>
+
+        {/* ── 料金プラン ── */}
+        <section
+          className="border-y border-[var(--rule)] py-16 lg:py-24"
+          style={{ background: "var(--paper-2)" }}
+        >
+          <motion.div
+            initial={fadeUp.initial}
+            whileInView={fadeUp.animate}
+            viewport={{ once: true, margin: "-80px" }}
+            transition={fadeUp.transition}
+            className="mx-auto max-w-5xl px-6"
+          >
+            <p
+              className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--ink-4)] text-center"
+            >
+              PRICING
+            </p>
+            <h2
+              className="mt-3 text-center text-[28px] font-black text-[var(--ink)] lg:text-[34px]"
+              style={{ letterSpacing: "-0.025em" }}
+            >
               シンプルな料金プラン
             </h2>
-            <div className="mt-10 grid gap-6 sm:grid-cols-2">
+            <div className="mt-10 grid gap-5 sm:grid-cols-2 sm:max-w-2xl sm:mx-auto">
               {/* Free */}
-              <div className="rounded-2xl border border-gray-200 bg-white p-8">
-                <p className="text-xs font-semibold uppercase tracking-widest text-gray-400">Free</p>
-                <p className="mt-2 text-4xl font-black text-gray-900">
-                  ¥0<span className="text-base font-normal text-gray-400">/月</span>
+              <div className="rounded-[var(--radius-card)] border border-[var(--rule)] bg-[var(--card)] p-7 shadow-[var(--shadow-card)]">
+                <p
+                  className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--ink-4)]"
+                >
+                  FREE
                 </p>
-                <p className="mt-1 text-sm text-gray-400">ずっと無料</p>
-                <ul className="mt-6 space-y-3 text-sm text-gray-700">
+                <p
+                  className="mt-2 text-[38px] font-black text-[var(--ink)]"
+                  style={{ letterSpacing: "-0.03em" }}
+                >
+                  ¥0
+                  <span className="text-base font-normal text-[var(--ink-4)]">/月</span>
+                </p>
+                <p className="mt-0.5 text-sm text-[var(--ink-4)]">ずっと無料</p>
+                <ul className="mt-6 space-y-2.5">
                   {FREE_FEATURES.map((f) => (
-                    <li key={f} className="flex items-start gap-2">
-                      <span className="text-gray-400">✓</span>
+                    <li key={f} className="flex items-start gap-2 text-sm text-[var(--ink-2)]">
+                      <span className="mt-0.5 text-[var(--s-done)] font-bold">✓</span>
                       <span>{f}</span>
                     </li>
                   ))}
                 </ul>
                 <Link
                   href="/login"
-                  className="mt-8 block rounded-xl border border-gray-300 px-4 py-2.5 text-center text-sm font-semibold text-gray-700 hover:bg-gray-50"
+                  className="mt-7 block rounded-[12px] border border-[var(--rule)] px-4 py-3 text-center text-sm font-semibold text-[var(--ink-2)] transition-colors hover:border-[var(--ink-3)] hover:bg-[var(--paper-2)]"
                 >
                   無料ではじめる
                 </Link>
               </div>
 
               {/* Pro */}
-              <div className="rounded-2xl border-2 border-indigo-500 bg-white p-8 shadow-lg shadow-indigo-100/50">
+              <div
+                className="rounded-[var(--radius-card)] p-7 text-white relative overflow-hidden"
+                style={{
+                  background: "var(--ink)",
+                  boxShadow: "var(--shadow-pop)",
+                }}
+              >
+                <span
+                  className="pointer-events-none absolute right-[-20px] bottom-[-50px] select-none leading-none font-black"
+                  style={{
+                    color: "rgba(255,255,255,0.05)",
+                    fontFamily: '"Noto Sans JP", serif',
+                    fontSize: 160,
+                    lineHeight: 1,
+                  }}
+                  aria-hidden="true"
+                >
+                  〆
+                </span>
                 <div className="flex items-center justify-between">
-                  <p className="text-xs font-semibold uppercase tracking-widest text-indigo-600">Pro</p>
-                  <span className="rounded-full bg-indigo-100 px-2.5 py-0.5 text-xs font-semibold text-indigo-700">おすすめ</span>
+                  <p
+                    className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-white/60"
+                  >
+                    PRO
+                  </p>
+                  <span className="rounded-full bg-brand/30 px-2.5 py-0.5 text-[11px] font-semibold text-brand-light">
+                    おすすめ
+                  </span>
                 </div>
-                <p className="mt-2 text-4xl font-black text-gray-900">
-                  ¥980<span className="text-base font-normal text-gray-400">/月</span>
+                <p
+                  className="mt-2 text-[38px] font-black"
+                  style={{ letterSpacing: "-0.03em" }}
+                >
+                  ¥980
+                  <span className="text-base font-normal text-white/50">/月</span>
                 </p>
-                <p className="mt-1 text-sm text-gray-400">税込</p>
-                <ul className="mt-6 space-y-3 text-sm text-gray-700">
+                <p className="mt-0.5 text-sm text-white/50">税込</p>
+                <ul className="mt-6 space-y-2.5">
                   {PRO_FEATURES.map((f) => (
-                    <li key={f} className="flex items-start gap-2">
-                      <span className="font-bold text-indigo-500">✓</span>
+                    <li key={f} className="flex items-start gap-2 text-sm text-white/80">
+                      <span className="mt-0.5 font-bold text-brand-light">✓</span>
                       <span>{f}</span>
                     </li>
                   ))}
                 </ul>
                 <Link
                   href="/login"
-                  className="mt-8 block rounded-xl bg-indigo-600 px-4 py-2.5 text-center text-sm font-semibold text-white hover:bg-indigo-700"
+                  className="relative z-10 mt-7 block rounded-[12px] bg-brand px-4 py-3 text-center text-sm font-bold text-white transition-colors hover:bg-brand-hover"
                 >
                   Pro ではじめる
                 </Link>
@@ -149,8 +303,8 @@ export function HomePageClient() {
           </motion.div>
         </section>
 
-        {/* CTA */}
-        <section className="bg-gray-50 py-24">
+        {/* ── CTA ── */}
+        <section className="py-20 lg:py-28">
           <motion.div
             initial={fadeUp.initial}
             whileInView={fadeUp.animate}
@@ -158,25 +312,116 @@ export function HomePageClient() {
             transition={fadeUp.transition}
             className="mx-auto max-w-xl px-6 text-center"
           >
-            <h2 className="text-3xl font-bold text-gray-900">
+            <h2
+              className="text-[28px] font-black text-[var(--ink)] lg:text-[34px]"
+              style={{ letterSpacing: "-0.025em" }}
+            >
               まず無料で試してみる
             </h2>
-            <p className="mt-4 text-gray-600">
+            <p className="mt-4 text-[var(--ink-3)]">
               登録はメールアドレスだけ。30秒ではじめられます。
             </p>
             <Link
               href="/login"
-              className="mt-8 inline-block rounded-xl bg-indigo-600 px-8 py-3 text-base font-semibold text-white shadow-lg shadow-indigo-200 hover:bg-indigo-700"
+              className="mt-8 inline-block rounded-[14px] bg-[var(--ink)] px-10 py-4 text-base font-bold text-[var(--paper)] transition-all hover:bg-brand hover:-translate-y-px"
+              style={{ boxShadow: "0 12px 32px -8px rgba(15,13,26,0.4)" }}
             >
-              無料登録はこちら
+              無料登録はこちら →
             </Link>
           </motion.div>
         </section>
       </main>
 
-      <footer className="border-t border-gray-100 py-8 text-center text-sm text-gray-400">
-        © 2026 〆トラ
+      {/* フッター */}
+      <footer className="border-t border-[var(--rule)] bg-[var(--paper-2)] py-6 text-center text-xs text-[var(--ink-4)]">
+        <nav className="space-x-4">
+          <Link href="/terms" className="hover:text-[var(--ink-2)] hover:underline">
+            利用規約
+          </Link>
+          <Link href="/privacy" className="hover:text-[var(--ink-2)] hover:underline">
+            プライバシーポリシー
+          </Link>
+          <Link href="/legal" className="hover:text-[var(--ink-2)] hover:underline">
+            特定商取引法に基づく表記
+          </Link>
+          <a href="mailto:support@shimetra.com" className="hover:text-[var(--ink-2)] hover:underline">
+            お問い合わせ
+          </a>
+        </nav>
+        <p className="mt-3">© 2026 〆トラ</p>
       </footer>
+    </div>
+  );
+}
+
+function AppPreview() {
+  return (
+    <div
+      className="rounded-[22px] p-5 shadow-[var(--shadow-pop)] relative overflow-hidden"
+      style={{ background: "var(--ink)" }}
+    >
+      {/* 装飾 */}
+      <span
+        className="pointer-events-none absolute select-none leading-none font-black"
+        style={{
+          color: "rgba(255,255,255,0.04)",
+          fontFamily: '"Noto Sans JP", serif',
+          fontSize: 180,
+          right: -20,
+          bottom: -56,
+          lineHeight: 1,
+        }}
+        aria-hidden="true"
+      >
+        〆
+      </span>
+
+      <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-white/50">
+        NEXT DEADLINE
+      </p>
+      <div className="mt-2 flex items-end gap-1">
+        <span
+          className="font-mono text-[52px] font-black leading-none tabular-nums text-white"
+          style={{ letterSpacing: "-0.04em" }}
+        >
+          3
+        </span>
+        <span className="mb-1 text-lg font-semibold text-white/70">日</span>
+      </div>
+      <p className="mt-2 font-semibold text-white/80">株式会社テクノロジー</p>
+      <span className="mt-1 inline-block rounded-full bg-[#e9defb] px-2 py-0.5 text-[11px] font-semibold text-[#5b3a93]">
+        ES
+      </span>
+
+      <div className="mt-4 h-1.5 overflow-hidden rounded-full bg-white/20">
+        <div className="h-full w-[78%] origin-left rounded-full bg-white/80" />
+      </div>
+
+      {/* ミニカード一覧 */}
+      <div className="mt-5 space-y-2.5">
+        {[
+          { company: "〇〇商事", kind: "説明会", days: 7, klass: "bg-[#d8eef0] text-[#1f6168]" },
+          { company: "△△銀行", kind: "面接", days: 14, klass: "bg-[#fde0c8] text-[#a04316]" },
+        ].map(({ company, kind, days, klass }) => (
+          <div
+            key={company}
+            className="flex items-center gap-3 rounded-[14px] border border-white/8 bg-white/8 p-3"
+          >
+            <div className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-full bg-white/10">
+              <span className="font-mono text-sm font-bold text-white tabular-nums">{days}</span>
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-semibold text-white">{company}</p>
+              <span className={`mt-0.5 inline-block rounded-[4px] px-1.5 py-0.5 text-[10px] font-bold ${klass}`}>
+                {kind}
+              </span>
+            </div>
+            <span className="shrink-0 rounded-full bg-white/10 px-2.5 py-1 text-[10px] font-semibold text-white/60">
+              未対応
+            </span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app/dashboard/DeadlineList.tsx
+++ b/src/app/dashboard/DeadlineList.tsx
@@ -60,9 +60,10 @@ const FILTER_CHIPS: { key: FilterState; label: string }[] = [
 
 type Props = {
   initialItems: DeadlineItem[];
+  totalCount?: number;
 };
 
-export default function DeadlineList({ initialItems }: Props) {
+export default function DeadlineList({ initialItems, totalCount }: Props) {
   const [items, setItems] = useState<DeadlineItem[]>(initialItems);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
@@ -159,22 +160,35 @@ export default function DeadlineList({ initialItems }: Props) {
   }
 
   return (
-    <div className="mt-4">
-      {/* フィルターチップ */}
-      <div className="flex gap-2">
-        {FILTER_CHIPS.map(({ key, label }) => (
-          <button
-            key={key}
-            onClick={() => setFilter(key)}
-            className={`rounded-full px-4 py-1.5 text-sm font-semibold transition-colors ${
-              filter === key
-                ? "bg-[var(--ink)] text-white"
-                : "bg-[var(--paper-2)] text-[var(--ink-3)] hover:text-[var(--ink-2)]"
-            }`}
-          >
-            {label}
-          </button>
-        ))}
+    <div className="mt-6">
+      {/* セクションヘッド */}
+      <div className="flex items-center justify-between mb-2.5">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-semibold text-[var(--ink-2)]">締切一覧</span>
+          {totalCount !== undefined && (
+            <span
+              className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[var(--paper-2)] px-1.5 font-mono text-[11px] font-semibold text-[var(--ink-3)]"
+            >
+              {totalCount}
+            </span>
+          )}
+        </div>
+        {/* フィルターチップ */}
+        <div className="flex gap-1">
+          {FILTER_CHIPS.map(({ key, label }) => (
+            <button
+              key={key}
+              onClick={() => setFilter(key)}
+              className={`rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors ${
+                filter === key
+                  ? "bg-[var(--ink)] text-[var(--paper)]"
+                  : "bg-[var(--paper-2)] text-[var(--ink-3)] hover:text-[var(--ink-2)]"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       </div>
 
       {errorMsg && (

--- a/src/app/dashboard/HeroCard.tsx
+++ b/src/app/dashboard/HeroCard.tsx
@@ -5,25 +5,28 @@ import { KIND_LABEL } from "@/features/deadlines/format";
 import type { DeadlineItem } from "./DeadlineList";
 
 const GREETINGS = [
-  [5, 11, "GOOD MORNING"],
-  [11, 17, "GOOD AFTERNOON"],
+  [5, 12, "GOOD MORNING"],
+  [12, 17, "GOOD AFTERNOON"],
   [17, 22, "GOOD EVENING"],
   [22, 24, "GOOD NIGHT"],
   [0, 5, "GOOD NIGHT"],
 ] as const;
 
 function greeting(h: number) {
-  return (
-    GREETINGS.find(([s, e]) => h >= s && h < e)?.[2] ?? "HELLO"
-  );
+  return GREETINGS.find(([s, e]) => h >= s && h < e)?.[2] ?? "HELLO";
 }
 
-function timeLeft(iso: string) {
+function timeLeft(iso: string): {
+  value: number;
+  unit: string;
+  overdue: boolean;
+  progress: number;
+} {
   const diffMs = new Date(iso).getTime() - Date.now();
   if (diffMs < 0) return { value: 0, unit: "期限切れ", overdue: true, progress: 1 };
   const hours = diffMs / (1000 * 60 * 60);
   const days = Math.floor(hours / 24);
-  const progress = Math.min(1, Math.max(0, (14 - days) / 14));
+  const progress = Math.max(0.06, Math.min(1, (14 - days) / 14));
   if (days > 0) return { value: days, unit: "日", overdue: false, progress };
   return { value: Math.ceil(hours), unit: "時間", overdue: false, progress };
 }
@@ -48,16 +51,24 @@ export function HeroCard({ item }: { item: DeadlineItem }) {
 
   return (
     <div
-      className="relative overflow-hidden rounded-[var(--radius-card)] p-6 text-white shadow-[var(--shadow-pop)]"
+      className="relative overflow-hidden rounded-[22px] px-6 py-5 text-white"
       style={{
         background: "var(--ink)",
+        boxShadow: "var(--shadow-pop)",
         animation: "pop-in 0.4s ease both",
       }}
     >
       {/* 装飾 〆 */}
       <span
-        className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 select-none text-[120px] font-black leading-none"
-        style={{ color: "rgba(246,244,255,0.06)" }}
+        className="pointer-events-none absolute select-none leading-none font-black"
+        style={{
+          color: "rgba(255,255,255,0.06)",
+          fontFamily: '"Noto Sans JP", serif',
+          fontSize: 220,
+          right: -22,
+          bottom: -56,
+          lineHeight: 1,
+        }}
         aria-hidden="true"
       >
         〆
@@ -65,25 +76,32 @@ export function HeroCard({ item }: { item: DeadlineItem }) {
 
       {/* パルスドット */}
       <div
-        className="absolute right-4 top-4 h-2 w-2 rounded-full bg-white"
+        className="absolute right-5 top-5 h-2 w-2 rounded-full bg-white"
         style={{ animation: "pulse-dot 2s ease-in-out infinite" }}
         aria-hidden="true"
       />
 
-      {/* 挨拶 */}
-      <p className="text-xs font-semibold uppercase tracking-widest opacity-60">
+      {/* グリーティング */}
+      <p
+        className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] opacity-60"
+      >
         {greet} · {dateLabel}
       </p>
 
       {/* カウントダウン */}
       <div className="mt-2 flex items-end gap-1">
         <span
-          className="font-mono text-6xl font-black leading-none tabular-nums"
-          style={{ color: overdue ? "var(--u-overdue)" : "white" }}
+          className="font-mono leading-none tabular-nums"
+          style={{
+            fontSize: 56,
+            fontWeight: 800,
+            letterSpacing: "-0.04em",
+            color: overdue ? "var(--u-overdue)" : "white",
+          }}
         >
           {value}
         </span>
-        <span className="mb-1 text-lg font-semibold opacity-80">{unit}</span>
+        <span className="mb-1.5 text-lg font-semibold opacity-80">{unit}</span>
       </div>
 
       {/* 企業名・種別 */}
@@ -94,11 +112,16 @@ export function HeroCard({ item }: { item: DeadlineItem }) {
         {KIND_LABEL[item.kind]}
       </span>
 
-      {/* プログレスバー */}
-      <div className="mt-4 h-1.5 overflow-hidden rounded-full bg-white/20">
+      {/* プログレスバー（drawProg アニメーション） */}
+      <div className="mt-5 h-1.5 overflow-hidden rounded-full bg-white/20">
         <div
-          className="h-full rounded-full bg-white/80"
-          style={{ width: `${progress * 100}%` }}
+          className="h-full origin-left rounded-full bg-white/80"
+          style={
+            {
+              animation: "draw-prog 1.1s cubic-bezier(.2,.8,.2,1) both",
+              "--p": progress,
+            } as React.CSSProperties
+          }
         />
       </div>
     </div>

--- a/src/app/dashboard/UrgencyRing.tsx
+++ b/src/app/dashboard/UrgencyRing.tsx
@@ -10,8 +10,13 @@ const RING_COLOR: Record<UrgencyLevel, string> = {
 const R = 22;
 const CIRC = 2 * Math.PI * R;
 
-function daysLeft(iso: string): number {
-  return (new Date(iso).getTime() - Date.now()) / (1000 * 60 * 60 * 24);
+function countdownParts(iso: string): { num: string; unit: string } {
+  const diffMs = new Date(iso).getTime() - Date.now();
+  if (diffMs <= 0) return { num: "!", unit: "OVER" };
+  const hours = diffMs / (1000 * 60 * 60);
+  const days = Math.floor(hours / 24);
+  if (days > 0) return { num: String(days), unit: "DAY" };
+  return { num: String(Math.ceil(hours)), unit: "HR" };
 }
 
 export function UrgencyRing({
@@ -21,14 +26,14 @@ export function UrgencyRing({
   iso: string;
   urgency: UrgencyLevel;
 }) {
-  const days = daysLeft(iso);
+  const days = (new Date(iso).getTime() - Date.now()) / (1000 * 60 * 60 * 24);
   const isOverdue = urgency === "overdue";
-
-  const ratio = isOverdue ? 1 : Math.min(1, Math.max(0, (14 - days) / 14));
+  const ratio = isOverdue
+    ? 1
+    : Math.min(1, Math.max(0.06, (14 - days) / 14));
   const offset = CIRC * (1 - ratio);
-
-  const label = isOverdue ? "!" : String(Math.ceil(Math.max(0, days)));
   const color = RING_COLOR[urgency];
+  const { num, unit } = countdownParts(iso);
 
   return (
     <div className="relative flex h-[52px] w-[52px] shrink-0 items-center justify-center">
@@ -56,20 +61,31 @@ export function UrgencyRing({
           strokeWidth="4"
           strokeLinecap="round"
           strokeDasharray={CIRC}
-          strokeDashoffset={offset}
-          style={{ animation: "ring-fill 1s ease both" }}
+          style={
+            {
+              animation: "ring-fill 1s cubic-bezier(.2,.8,.2,1) both",
+              "--ring-from": `${CIRC}`,
+              "--ring-to": `${offset}`,
+            } as React.CSSProperties
+          }
         />
       </svg>
       <div
         className="absolute inset-0 flex flex-col items-center justify-center"
         style={{ color }}
       >
-        <span className="font-mono text-sm font-bold leading-none tabular-nums">
-          {label}
+        <span
+          className="font-mono font-extrabold leading-none tabular-nums"
+          style={{ fontSize: 18, letterSpacing: "-0.04em" }}
+        >
+          {num}
         </span>
-        {!isOverdue && (
-          <span className="text-[9px] leading-none opacity-70">日</span>
-        )}
+        <span
+          className="mt-0.5 font-semibold leading-none text-[var(--ink-3)]"
+          style={{ fontSize: 9 }}
+        >
+          {unit}
+        </span>
       </div>
     </div>
   );

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,6 +6,13 @@ import { HeroCard } from "./HeroCard";
 import { FREE_ITEM_LIMIT, isProUser } from "@/features/deadlines/gate";
 import { trackEvent } from "@/features/analytics";
 
+function getGreeting(h: number): string {
+  if (h >= 5 && h < 12) return "GOOD MORNING";
+  if (h < 17) return "GOOD AFTERNOON";
+  if (h < 22) return "GOOD EVENING";
+  return "GOOD NIGHT";
+}
+
 export default async function DashboardPage() {
   const session = await requireSession();
 
@@ -33,21 +40,102 @@ export default async function DashboardPage() {
     deadlineAt: row.deadlineAt.toISOString(),
   }));
 
+  const now = new Date();
+  const h = now.getHours();
+  const dateLabel = now.toLocaleDateString("ja-JP", {
+    month: "long",
+    day: "numeric",
+    weekday: "short",
+  });
+
+  const todoItems = items.filter((i) => i.status === "todo");
+  const overdueItems = todoItems.filter((i) => new Date(i.deadlineAt) < now);
+  const doneItems = items.filter(
+    (i) => i.status === "done" || i.status === "submitted",
+  );
+
   const isAtFreeLimit = !pro && items.length >= FREE_ITEM_LIMIT;
-  const nextItem = items.find((i) => i.status === "todo") ?? null;
+  const nextItem = todoItems[0] ?? null;
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-6">
-      {/* HeroCard: 次の締切カウントダウン */}
+      {/* グリーティング行 */}
+      <div className="flex items-baseline justify-between gap-3 mb-1.5">
+        <span
+          className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--ink-4)]"
+        >
+          {getGreeting(h)}
+        </span>
+        <span className="text-xs text-[var(--ink-4)]">{dateLabel}</span>
+      </div>
+      <h1
+        className="text-[24px] font-extrabold text-[var(--ink)] leading-tight"
+        style={{ letterSpacing: "-0.025em" }}
+      >
+        {todoItems.length === 0
+          ? "締切アイテムはありません"
+          : `今日の締切は${overdueItems.length > 0 ? `${overdueItems.length}件期限切れ` : `${todoItems.length}件あります`}。`}
+      </h1>
+
+      {/* HeroCard */}
       {nextItem && (
-        <div className="mb-6">
+        <div className="mt-4">
           <HeroCard item={nextItem} />
+        </div>
+      )}
+
+      {/* KPI タイル */}
+      {items.length > 0 && (
+        <div className="mt-4 grid grid-cols-3 gap-2">
+          <div className="rounded-[14px] border border-[var(--rule)] bg-[var(--card)] px-3 py-3">
+            <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-[var(--ink-4)]">
+              TODO
+            </p>
+            <p
+              className="mt-1 text-[24px] font-extrabold text-[var(--ink)]"
+              style={{ letterSpacing: "-0.03em" }}
+            >
+              {todoItems.length}
+            </p>
+          </div>
+          <div
+            className={`rounded-[14px] border px-3 py-3 ${
+              overdueItems.length > 0
+                ? "border-[rgba(210,58,58,0.2)] bg-[var(--u-overdue-bg)]"
+                : "border-[var(--rule)] bg-[var(--card)]"
+            }`}
+          >
+            <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-[var(--ink-4)]">
+              OVERDUE
+            </p>
+            <p
+              className="mt-1 text-[24px] font-extrabold"
+              style={{
+                letterSpacing: "-0.03em",
+                color:
+                  overdueItems.length > 0 ? "var(--u-overdue)" : "var(--ink)",
+              }}
+            >
+              {overdueItems.length}
+            </p>
+          </div>
+          <div className="rounded-[14px] border border-[var(--rule)] bg-[var(--card)] px-3 py-3">
+            <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-[var(--ink-4)]">
+              DONE
+            </p>
+            <p
+              className="mt-1 text-[24px] font-extrabold text-[var(--s-done)]"
+              style={{ letterSpacing: "-0.03em" }}
+            >
+              {doneItems.length}
+            </p>
+          </div>
         </div>
       )}
 
       {/* Free 枠上限バナー */}
       {isAtFreeLimit && (
-        <div className="mb-4 flex items-center justify-between rounded-[var(--radius-card)] border border-[var(--u-soon-bg)] bg-[var(--u-soon-bg)] px-4 py-3 text-sm">
+        <div className="mt-4 flex items-center justify-between rounded-[var(--radius-card)] border border-[var(--u-soon-bg)] bg-[var(--u-soon-bg)] px-4 py-3 text-sm">
           <p className="text-[var(--u-soon)]">
             <span className="font-semibold">
               Free プランの上限（{FREE_ITEM_LIMIT}件）に達しています。
@@ -65,7 +153,7 @@ export default async function DashboardPage() {
       )}
 
       {/* 締切一覧 */}
-      <DeadlineList initialItems={items} />
+      <DeadlineList initialItems={items} totalCount={items.length} />
     </main>
   );
 }

--- a/src/app/deadline/new/DeadlineForm.tsx
+++ b/src/app/deadline/new/DeadlineForm.tsx
@@ -393,21 +393,7 @@ export default function DeadlineForm(props: Props) {
       </div>
 
       {/* 通知スケジュールプレビュー */}
-      <div className="rounded-[var(--radius-card)] border border-[var(--rule)] bg-[var(--paper)] p-4">
-        <p className="text-xs font-semibold uppercase tracking-widest text-[var(--ink-3)]">
-          通知スケジュール
-        </p>
-        <div className="mt-3 space-y-2">
-          {["72時間前", "24時間前", "3時間前"].map((label) => (
-            <div key={label} className="flex items-center gap-2">
-              <div className="h-1.5 w-1.5 rounded-full bg-brand" />
-              <span className="text-sm text-[var(--ink-2)]">
-                {label}にメール通知
-              </span>
-            </div>
-          ))}
-        </div>
-      </div>
+      <NotifyPreview deadlineAt={deadlineAt} />
 
       {/* スティッキー保存バー */}
       <div className="sticky bottom-0 -mx-6 border-t border-[var(--rule)] bg-[var(--paper)]/95 px-6 py-4 backdrop-blur-sm">
@@ -434,5 +420,49 @@ export default function DeadlineForm(props: Props) {
         </div>
       </div>
     </form>
+  );
+}
+
+const NOTIFY_OFFSETS = [
+  { label: "72時間前", hours: 72 },
+  { label: "24時間前", hours: 24 },
+  { label: "3時間前", hours: 3 },
+];
+
+function formatNotifyTime(iso: string, offsetHours: number): string {
+  const d = new Date(new Date(iso).getTime() - offsetHours * 3600 * 1000);
+  return d.toLocaleString("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    month: "numeric",
+    day: "numeric",
+    weekday: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function NotifyPreview({ deadlineAt }: { deadlineAt: string }) {
+  const hasDeadline = Boolean(deadlineAt);
+  const deadlineIso = hasDeadline ? deadlineAt + "+09:00" : "";
+
+  return (
+    <div className="rounded-[var(--radius-card)] border border-[var(--rule)] bg-[var(--brand-50)] p-4">
+      <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--ink-4)]">
+        通知スケジュール
+      </p>
+      <div className="mt-3 space-y-2.5">
+        {NOTIFY_OFFSETS.map(({ label, hours }) => (
+          <div key={label} className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <div className="h-1.5 w-1.5 shrink-0 rounded-full bg-brand" />
+              <span className="text-sm text-[var(--ink-2)]">{label}にメール通知</span>
+            </div>
+            <span className="font-mono text-xs text-[var(--ink-3)]">
+              {hasDeadline ? formatNotifyTime(deadlineIso, hours) : "──"}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -138,3 +138,42 @@ body {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* ─── Stagger animation ─────────────────────────────────── */
+.stagger > * { animation: fade-up 480ms cubic-bezier(.2,.8,.2,1) both; }
+.stagger > *:nth-child(1) { animation-delay: 40ms; }
+.stagger > *:nth-child(2) { animation-delay: 100ms; }
+.stagger > *:nth-child(3) { animation-delay: 160ms; }
+.stagger > *:nth-child(4) { animation-delay: 220ms; }
+.stagger > *:nth-child(5) { animation-delay: 280ms; }
+.stagger > *:nth-child(6) { animation-delay: 340ms; }
+.stagger > *:nth-child(7) { animation-delay: 400ms; }
+.stagger > *:nth-child(8) { animation-delay: 460ms; }
+
+/* ─── Brand seal (header) ───────────────────────────────── */
+.brand-seal::after {
+  content: "";
+  position: absolute;
+  inset: 2px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 5px;
+  pointer-events: none;
+}
+
+/* ─── Big seal (login) ──────────────────────────────────── */
+.big-seal::before {
+  content: "";
+  position: absolute;
+  inset: -8px;
+  border: 1.5px dashed var(--rule);
+  border-radius: 28px;
+  pointer-events: none;
+}
+.big-seal::after {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border: 1.5px solid rgba(255, 255, 255, 0.15);
+  border-radius: 16px;
+  pointer-events: none;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default async function RootLayout({
         <GtmScript />
         {session && <ConditionalHeader email={session.email} />}
         <div className="flex-1">{children}</div>
-        <footer className="border-t border-indigo-100 bg-gray-50 py-4 text-center text-xs text-slate-500">
+        <footer className="border-t border-[var(--rule)] bg-[var(--paper-2)] py-4 text-center text-xs text-[var(--ink-4)]">
           <nav className="space-x-4">
             <Link href="/terms" className="hover:underline">
               利用規約

--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -45,22 +45,21 @@ export default function LoginForm() {
   }
 
   return (
-    <div className="mt-6">
-      {/* URL のエラークエリ（expired / invalid / server） */}
+    <div className="space-y-4">
       {urlError && ERROR_MESSAGES[urlError] && (
-        <p className="mb-4 rounded-lg bg-red-50 px-4 py-2 text-sm text-red-700">
+        <p className="rounded-xl bg-[var(--u-overdue-bg)] px-4 py-2.5 text-sm text-[var(--u-overdue)]">
           {ERROR_MESSAGES[urlError]}
         </p>
       )}
 
       {status === "sent" ? (
-        <div className="rounded-lg bg-green-50 px-4 py-4 text-sm text-green-800">
-          <p className="font-semibold">メールを送信しました 📬</p>
-          <p className="mt-1">
+        <div className="rounded-[var(--radius-card)] border border-[var(--rule)] bg-[var(--card)] px-5 py-5">
+          <p className="text-base font-bold text-[var(--ink)]">メールを送信しました</p>
+          <p className="mt-2 text-sm text-[var(--ink-2)]">
             <span className="font-mono text-xs">{email}</span>{" "}
             宛にログインリンクを送りました。
           </p>
-          <p className="mt-2 text-xs text-green-700">
+          <p className="mt-1.5 text-xs text-[var(--ink-3)]">
             リンクの有効期限は 30 分です。届かない場合は迷惑メールをご確認ください。
           </p>
           <button
@@ -68,52 +67,74 @@ export default function LoginForm() {
               setStatus("idle");
               setEmail("");
             }}
-            className="mt-3 text-xs text-green-700 underline"
+            className="mt-3 text-xs text-[var(--ink-3)] underline hover:text-[var(--ink-2)]"
           >
             別のアドレスで送り直す
           </button>
         </div>
       ) : (
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label
-              htmlFor="email"
-              className="block text-sm font-medium text-[var(--ink-2)]"
-            >
-              メールアドレス
-            </label>
-            <div className="relative mt-1">
-              <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-[var(--ink-3)]">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <rect width="20" height="16" x="2" y="4" rx="2" />
-                  <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
-                </svg>
-              </span>
-              <input
-                id="email"
-                type="email"
-                required
-                autoFocus
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="you@example.com"
-                className="block w-full rounded-lg border border-[var(--rule)] bg-white pl-9 pr-3 py-3 text-sm text-[var(--ink)] placeholder:text-[var(--ink-4)] outline-none focus:border-brand focus:ring-2 focus:ring-brand/20"
-              />
-            </div>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          {/* input-shell */}
+          <div
+            className="flex items-center rounded-[14px] border-[1.5px] border-[var(--rule)] bg-[var(--card)] px-3.5 transition-all focus-within:border-brand focus-within:shadow-[0_0_0_4px_#eef2ff]"
+          >
+            <span className="pointer-events-none shrink-0 text-[var(--ink-3)]">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <rect width="20" height="16" x="2" y="4" rx="2" />
+                <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+              </svg>
+            </span>
+            <input
+              id="email"
+              type="email"
+              required
+              autoFocus
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              className="flex-1 border-none bg-transparent px-3 py-3.5 text-[15px] text-[var(--ink)] outline-none placeholder:text-[var(--ink-4)]"
+            />
           </div>
 
           {status === "error" && (
-            <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">
+            <p className="rounded-xl bg-[var(--u-overdue-bg)] px-3 py-2 text-sm text-[var(--u-overdue)]">
               {apiError}
             </p>
           )}
 
+          {/* btn-primary */}
           <button
             type="submit"
             disabled={status === "loading"}
-            className="w-full rounded-lg bg-[var(--ink)] px-4 py-3 text-sm font-semibold text-white hover:bg-brand transition-colors disabled:opacity-60"
+            className="mt-1 flex w-full items-center justify-center gap-2 rounded-[14px] bg-[var(--ink)] px-4 py-[15px] text-[15px] font-bold text-[var(--paper)] transition-all hover:bg-brand disabled:opacity-60"
           >
-            {status === "loading" ? "送信中…" : "マジックリンクを送信"}
+            {status === "loading" ? (
+              <>
+                <svg
+                  className="h-4 w-4 animate-spin"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+                </svg>
+                送信中…
+              </>
+            ) : (
+              "マジックリンクを送信"
+            )}
           </button>
         </form>
       )}

--- a/src/app/login/_components/NotificationToast.tsx
+++ b/src/app/login/_components/NotificationToast.tsx
@@ -14,17 +14,27 @@ export function NotificationToast() {
 
   return (
     <div
+      className="flex items-start gap-3 rounded-[18px] border border-[var(--rule)] bg-[var(--card)] p-3 shadow-[var(--shadow-pop)]"
       style={{ animation: "slide-in-down 0.35s ease both" }}
-      className="flex items-center gap-3 rounded-2xl bg-white px-4 py-3 shadow-lg shadow-black/10"
     >
-      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-brand text-white text-lg font-black">
+      {/* アプリアイコン */}
+      <div
+        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[9px] bg-[var(--ink)] text-white"
+        style={{
+          fontFamily: '"Noto Sans JP", serif',
+          fontWeight: 900,
+          fontSize: 18,
+        }}
+        aria-hidden="true"
+      >
         〆
       </div>
-      <div className="min-w-0">
-        <p className="text-xs font-semibold text-[var(--ink-3)]">〆トラ</p>
-        <p className="text-sm font-medium text-[var(--ink)] truncate">
+      <div className="min-w-0 flex-1">
+        <p className="text-[11px] font-semibold text-[var(--ink-3)]">〆トラ · 通知</p>
+        <p className="mt-0.5 text-sm font-medium text-[var(--ink)] leading-snug">
           ⏰ 明日 9:00 締切 — 〇〇商事 ES
         </p>
+        <p className="mt-0.5 text-[11px] text-[var(--ink-4)]">たった今</p>
       </div>
     </div>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,45 +6,121 @@ export const metadata = {
   title: "ログイン | 〆トラ",
 };
 
-function SealLogo() {
-  return (
-    <div
-      style={{ animation: "wiggle 2s ease-in-out infinite" }}
-      className="mx-auto flex h-20 w-20 items-center justify-center rounded-2xl bg-brand text-4xl font-black text-white shadow-lg shadow-brand/30"
-    >
-      〆
-    </div>
-  );
-}
-
 export default function LoginPage() {
   return (
-    <main className="min-h-screen bg-[var(--paper)] flex flex-col items-center justify-center px-4 py-12">
-      <div className="w-full max-w-sm space-y-8">
-        {/* 〆印章ロゴ＋キャッチコピー＋通知トースト */}
-        <div className="text-center space-y-4">
-          <SealLogo />
-          <h1 className="text-2xl font-black tracking-tight text-[var(--ink)]">
-            締切を、出し忘れない人生に。
+    <main className="min-h-screen bg-[var(--paper)] flex flex-col lg:flex-row">
+      {/* ── 左カラム（PC では brand 紹介） ── */}
+      <div className="hidden lg:flex lg:flex-1 lg:flex-col lg:justify-between bg-[var(--ink)] text-white px-12 py-14 relative overflow-hidden">
+        {/* 装飾 〆 */}
+        <span
+          className="pointer-events-none select-none absolute right-[-40px] bottom-[-80px] text-[320px] font-black leading-none"
+          style={{ color: "rgba(255,255,255,0.04)", fontFamily: '"Noto Sans JP", serif' }}
+          aria-hidden="true"
+        >
+          〆
+        </span>
+
+        {/* ロゴ */}
+        <div className="flex items-center gap-2.5">
+          <span
+            className="brand-seal relative inline-flex h-[34px] w-[34px] items-center justify-center rounded-[9px] bg-white text-[var(--ink)]"
+            style={{
+              fontFamily: '"Noto Sans JP", serif',
+              fontWeight: 900,
+              fontSize: 20,
+              transform: "rotate(-4deg)",
+            }}
+            aria-hidden="true"
+          >
+            〆
+          </span>
+          <span className="text-[18px] font-extrabold text-white" style={{ letterSpacing: "-0.02em" }}>
+            トラ
+          </span>
+        </div>
+
+        {/* キャッチコピー */}
+        <div className="mt-auto mb-auto space-y-5 relative z-10">
+          <h1
+            className="text-[38px] font-black leading-tight"
+            style={{ letterSpacing: "-0.035em" }}
+          >
+            締切を、<br />出し忘れない<br />人生に。
           </h1>
-          {/* useSearchParams を使う LoginForm は Suspense で囲む */}
+          <p className="text-[var(--ink-4)] text-base leading-relaxed max-w-[280px]">
+            ES・説明会・面接の締切を一元管理し、<br />
+            締切前にメールで通知します。
+          </p>
+          <ul className="space-y-2 text-sm">
+            {[
+              "締切72時間前・24時間前・3時間前に通知",
+              "クレジットカード不要で10件まで無料",
+              "メールアドレスだけで30秒登録",
+            ].map((item) => (
+              <li key={item} className="flex items-center gap-2 text-white/70">
+                <span className="text-brand font-bold">✓</span>
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* 通知トースト（PC） */}
+        <div className="relative z-10">
+          <Suspense>
+            <NotificationToast />
+          </Suspense>
+        </div>
+      </div>
+
+      {/* ── 右カラム（フォーム） ── */}
+      <div className="flex flex-1 flex-col px-6 py-10 lg:px-14 lg:py-14 lg:max-w-[480px]">
+        {/* モバイルのみ: トースト */}
+        <div className="mb-8 lg:hidden">
           <Suspense>
             <NotificationToast />
           </Suspense>
         </div>
 
-        {/* ログインフォーム */}
-        <div className="rounded-2xl border border-[var(--rule)] bg-white p-8 shadow-sm">
-          <h2 className="text-lg font-bold text-[var(--ink)]">
-            ログイン / サインアップ
-          </h2>
-          <p className="mt-1 text-sm text-[var(--ink-3)]">
-            メールアドレスを入力するとログインリンクを送ります。
-          </p>
+        {/* big-seal */}
+        <div className="mb-8">
+          <div
+            className="big-seal relative inline-flex h-[88px] w-[88px] items-center justify-center rounded-[22px] bg-[var(--ink)] text-white"
+            style={{
+              fontFamily: '"Noto Sans JP", serif',
+              fontWeight: 900,
+              fontSize: 52,
+              letterSpacing: "-0.04em",
+              transform: "rotate(-3deg)",
+            }}
+          >
+            〆
+          </div>
+        </div>
+
+        <h1
+          className="text-[30px] font-black text-[var(--ink)] leading-tight"
+          style={{ letterSpacing: "-0.035em" }}
+        >
+          締切を、出し忘れない人生に。
+        </h1>
+        <p className="mt-2 text-sm text-[var(--ink-3)]">
+          メールアドレスを入力するとログインリンクを送ります。
+        </p>
+
+        <div className="mt-8">
           <Suspense>
             <LoginForm />
           </Suspense>
         </div>
+
+        <p className="mt-auto pt-10 text-xs text-[var(--ink-4)] text-center">
+          ログインすることで
+          <a href="/terms" className="underline hover:text-[var(--ink-2)]">利用規約</a>
+          ・
+          <a href="/privacy" className="underline hover:text-[var(--ink-2)]">プライバシーポリシー</a>
+          に同意したものとみなします。
+        </p>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary

- **AppHeader**: brand-seal（30px・-4deg 回転・内側白ボーダー擬似要素）+ 検索/通知/ログアウトのアイコンボタン（38px 角丸、ホバーで translateY）
- **HomePageClient（LP）**: Paper デザインシステム全面適用。デスクトップは 2 カラム Hero（左: 大きな big-seal + 見出し + CTA、右: アプリ UI プレビュー）。問題提起 3 カード・How it works 3 ステップ・料金プランも CSS 変数で統一
- **login/page.tsx**: big-seal（88px・-3deg・破線外枠・内側白ボーダー）左寄せレイアウト。デスクトップは 2 カラム（左: brand 紹介パネル、右: フォーム）
- **LoginForm**: input-shell スタイル（外枠のみ、focus-within でブランドカラー + ring）+ btn-primary（bg-ink → hover: brand）
- **NotificationToast**: iOS 風トースト（アプリアイコン + タイトル + 時刻）
- **dashboard/page.tsx**: グリーティング行（JetBrains Mono ラベル + 日付）+ KPI タイル 3 列（TODO/OVERDUE/DONE）
- **HeroCard**: プログレスバーを `scaleX(var(--p))` + `draw-prog` アニメーションに変更
- **UrgencyRing**: CSS 変数アニメーション（`--ring-from`/`--ring-to`）で正確な進捗を描画。センターラベルを DAY/HR/OVER に変更
- **DeadlineList**: セクションヘッド（左: "締切一覧" + 件数バッジ、右: フィルターチップ）
- **DeadlineForm**: 通知スケジュールプレビューを実際の計算済み日時で表示
- **globals.css**: stagger アニメーション (nth-child) + brand-seal/big-seal の擬似要素スタイル
- **layout.tsx**: フッターを CSS 変数に統一

## Test plan

- [x] `npx tsc --noEmit` — エラーなし ✅
- [x] `npm run build` — ビルドエラーなし ✅
- [x] `/` (LP): Paper背景・big-seal・2カラム Hero・アプリプレビューを目視確認
- [x] `/login`: big-seal 左寄せ・input-shell・btn-primary を目視確認
- [x] `/dashboard`: グリーティング・KPI タイル・HeroCard プログレスバーを目視確認
- [x] `/deadline/new`: 通知スケジュールに実際の日時が表示されることを確認
- [x] モバイル（390px）と PC（1280px）両方で確認