### PR TITLE
design(lp): landing.html のデザインを LP へ忠実に実装する

### DIFF
--- a/src/app/_components/ConditionalFooter.tsx
+++ b/src/app/_components/ConditionalFooter.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const LP_PATHS = ["/"];
+
+export function ConditionalFooter() {
+  const pathname = usePathname();
+  if (LP_PATHS.includes(pathname)) return null;
+
+  return (
+    <footer className="border-t border-[var(--rule)] bg-[var(--paper-2)] py-4 text-center text-xs text-[var(--ink-4)]">
+      <nav className="space-x-4">
+        <Link href="/terms" className="hover:underline">
+          利用規約
+        </Link>
+        <Link href="/privacy" className="hover:underline">
+          プライバシーポリシー
+        </Link>
+        <Link href="/legal" className="hover:underline">
+          特定商取引法に基づく表記
+        </Link>
+        <a href="mailto:support@shimetra.com" className="hover:underline">
+          お問い合わせ
+        </a>
+      </nav>
+    </footer>
+  );
+}

--- a/src/app/_components/HomePageClient.tsx
+++ b/src/app/_components/HomePageClient.tsx
@@ -1,427 +1,848 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { motion } from "framer-motion";
-import { fadeUp } from "@/lib/motion";
-import { FREE_FEATURES, PRO_FEATURES } from "@/config/plans";
+import { PRO_PRICE_JPY } from "@/config/plans";
+import "@/app/lp.css";
 
-const PROBLEMS = [
-  { icon: "📭", text: "気づいたら締切が過ぎていた" },
-  { icon: "🗂️", text: "複数企業の締切を覚えきれない" },
-  { icon: "😓", text: "Notion に書いたが更新が止まった" },
+const MARQUEE_ITEMS: [string, string][] = [
+  ["エントリーシート", "23:59"],
+  ["説明会", "5月14日"],
+  ["面接", "一次／二次／最終"],
+  ["本日締切", "TODAY"],
+  ["72時間前", "NOTIFY"],
+  ["寝落ち、なし", "NEVER MISS"],
 ];
 
-const HOW_STEPS = [
-  { num: "01", title: "締切を登録する", desc: "企業名・種別・締切日時をサッと入力。リンクやメモも保存できます。" },
-  { num: "02", title: "通知が届く", desc: "締切の 72時間前・24時間前・3時間前にメールで通知します。" },
-  { num: "03", title: "出し忘れゼロへ", desc: "通知を受け取り、ステータスを更新。就活の締切を確実に守れます。" },
+const FREE_LIST = [
+  "締切アイテム10件まで",
+  "締切24時間前のメール通知",
+  "4階調の緊急度 × 4種類の選考タグ",
+  "ステータス管理",
+  "マジックリンク認証（パスワード不要）",
 ];
+
+const PRO_LIST = [
+  "締切アイテム 無制限",
+  "締切 72 / 24 / 3時間前の通知",
+  "4階調の緊急度 × 4種類の選考タグ",
+  "FREE の全機能",
+];
+
+const URG_CARDS = [
+  { cls: "overdue", off: 0,   label: "● Overdue ／ 期限切れ", title: "取り逃した。",  desc: "過ぎた時間はゼロにできない。だから〆トラは、過ぎる前に止める設計。", n: "−02h", u: "過ぎた" },
+  { cls: "today",   off: 32,  label: "● Today ／ 当日",       title: "今日が、勝負。", desc: "濃いオレンジで、視界の中心に。寝落ちする前に、確実に呼び戻す。",     n: "07h",  u: "あと" },
+  { cls: "soon",    off: 160, label: "● Soon ／ 3日以内",     title: "視界の端へ。",  desc: "準備期間。落ち着いた黄色で、近づいていることだけを知らせる。",       n: "2d",   u: "あと" },
+  { cls: "normal",  off: 260, label: "● Normal ／ 通常",      title: "まだ、余裕。",  desc: "ブランドの紺で、リストの背景に。今日は、別のことに集中していい。",   n: "11d",  u: "あと" },
+];
+
+const pad = (n: number) => String(n).padStart(2, "0");
 
 export function HomePageClient() {
+  const navRef        = useRef<HTMLElement>(null);
+  const phoneRef      = useRef<HTMLDivElement>(null);
+  const heroMarkRef   = useRef<HTMLSpanElement>(null);
+  const heroRightRef  = useRef<HTMLDivElement>(null);
+  const hourRef       = useRef<HTMLSpanElement>(null);
+  const minRef        = useRef<HTMLSpanElement>(null);
+  const secRef        = useRef<HTMLSpanElement>(null);
+  const b1TimerRef    = useRef<HTMLDivElement>(null);
+  const ctaMarkRef    = useRef<HTMLSpanElement>(null);
+  const ctaSectionRef = useRef<HTMLElement>(null);
+  const stat82Ref     = useRef<HTMLDivElement>(null);
+
+  const [email,     setEmail]     = useState("");
+  const [submitted, setSubmitted] = useState(false);
+  const [sending,   setSending]   = useState(false);
+  const [errMsg,    setErrMsg]    = useState("");
+
+  /* ── nav scroll shadow ── */
+  useEffect(() => {
+    const nav = navRef.current;
+    if (!nav) return;
+    const onScroll = () => nav.classList.toggle("scrolled", window.scrollY > 8);
+    window.addEventListener("scroll", onScroll, { passive: true });
+    onScroll();
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  /* ── IntersectionObserver reveal for [data-reveal] ── */
+  useEffect(() => {
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          if (e.isIntersecting) { e.target.classList.add("in-view"); io.unobserve(e.target); }
+        });
+      },
+      { threshold: 0.18, rootMargin: "0px 0px -8% 0px" },
+    );
+    document.querySelectorAll("[data-reveal]").forEach((el) => io.observe(el));
+    return () => io.disconnect();
+  }, []);
+
+  /* ── phone countdown ── */
+  useEffect(() => {
+    let remaining = 7 * 3600 + 17 * 60 + 42;
+    const tick = () => {
+      const h = Math.floor(remaining / 3600);
+      const m = Math.floor((remaining % 3600) / 60);
+      const s = remaining % 60;
+      if (hourRef.current) hourRef.current.textContent = pad(h);
+      if (minRef.current)  minRef.current.textContent  = pad(m);
+      if (secRef.current)  secRef.current.textContent  = pad(s);
+      remaining = Math.max(0, remaining - 1);
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  /* ── bento b-1 timer d/h alternating ── */
+  useEffect(() => {
+    const el = b1TimerRef.current;
+    if (!el) return;
+    let big = 7, isDays = true;
+    const id = setInterval(() => {
+      if (isDays) {
+        big = (big % 14) + 1;
+        el.innerHTML = `${pad(big)}<span class="unit">d</span>`;
+      } else {
+        big = Math.max(1, (big + 3) % 24);
+        el.innerHTML = `${pad(big)}<span class="unit">h</span>`;
+      }
+      isDays = !isDays;
+    }, 2200);
+    return () => clearInterval(id);
+  }, []);
+
+  /* ── hero parallax ── */
+  useEffect(() => {
+    const phone    = phoneRef.current;
+    const heroMark = heroMarkRef.current;
+    const heroRight = heroRightRef.current;
+    if (!heroRight || !phone) return;
+
+    let raf: number | null = null;
+    let targetX = 0, targetY = 0, curX = 0, curY = 0;
+
+    const onMove = (e: MouseEvent) => {
+      const r = heroRight.getBoundingClientRect();
+      targetX = (e.clientX - (r.left + r.width  / 2)) / r.width;
+      targetY = (e.clientY - (r.top  + r.height / 2)) / r.height;
+      if (!raf) raf = requestAnimationFrame(loop);
+    };
+    const onLeave = () => { targetX = targetY = 0; };
+
+    function loop() {
+      curX += (targetX - curX) * 0.08;
+      curY += (targetY - curY) * 0.08;
+      phone!.style.transform = `rotate(${-3 + curX * 4}deg) translate(${curX * 12}px, ${curY * 10}px)`;
+      if (heroMark) heroMark.style.transform = `rotate(${-6 + curX * 2}deg) translate(${curX * -22}px, ${curY * -16}px)`;
+      if (Math.abs(targetX - curX) > 0.001 || Math.abs(targetY - curY) > 0.001) {
+        raf = requestAnimationFrame(loop);
+      } else {
+        raf = null;
+      }
+    }
+
+    heroRight.addEventListener("mousemove", onMove);
+    heroRight.addEventListener("mouseleave", onLeave);
+    return () => {
+      heroRight.removeEventListener("mousemove", onMove);
+      heroRight.removeEventListener("mouseleave", onLeave);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  /* ── magnet buttons ── */
+  useEffect(() => {
+    type Handler = { btn: HTMLElement; move: (e: MouseEvent) => void; leave: () => void };
+    const handlers: Handler[] = [];
+
+    document.querySelectorAll<HTMLElement>(".lp-btn-magnet").forEach((btn) => {
+      const move = (e: MouseEvent) => {
+        const r = btn.getBoundingClientRect();
+        const x = e.clientX - (r.left + r.width  / 2);
+        const y = e.clientY - (r.top  + r.height / 2);
+        btn.style.transform = `translate(${x * 0.18}px, ${y * 0.22}px)`;
+      };
+      const leave = () => { btn.style.transform = ""; };
+      btn.addEventListener("mousemove", move);
+      btn.addEventListener("mouseleave", leave);
+      handlers.push({ btn, move, leave });
+    });
+
+    return () => handlers.forEach(({ btn, move, leave }) => {
+      btn.removeEventListener("mousemove", move);
+      btn.removeEventListener("mouseleave", leave);
+    });
+  }, []);
+
+  /* ── CTA mark scroll drift ── */
+  useEffect(() => {
+    const ctaMark = ctaMarkRef.current;
+    const cta     = ctaSectionRef.current;
+    if (!ctaMark || !cta) return;
+
+    const onScroll = () => {
+      const r  = cta.getBoundingClientRect();
+      const vh = window.innerHeight;
+      const progress = Math.max(0, Math.min(1, (vh - r.top) / (vh + r.height)));
+      ctaMark.style.transform = `rotate(${-10 + progress * 20}deg) scale(${0.92 + progress * 0.16})`;
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    onScroll();
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  /* ── stats counter animate (82%) ── */
+  useEffect(() => {
+    const numEl = stat82Ref.current;
+    if (!numEl) return;
+    const row = numEl.closest(".lp-stat-row") as HTMLElement | null;
+    if (!row) return;
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          if (!e.isIntersecting) return;
+          const dur = 1200, t0 = performance.now();
+          function step(t: number) {
+            const p = Math.min(1, (t - t0) / dur);
+            const v = Math.floor((1 - Math.pow(1 - p, 3)) * 82);
+            numEl!.innerHTML = `${v}<span class="pct">%</span>`;
+            if (p < 1) requestAnimationFrame(step);
+          }
+          requestAnimationFrame(step);
+          io.unobserve(row!);
+        });
+      },
+      { threshold: 0.5 },
+    );
+    io.observe(row);
+    return () => io.disconnect();
+  }, []);
+
+  /* ── smooth anchor scroll (offset for fixed nav) ── */
+  useEffect(() => {
+    type H = { el: HTMLAnchorElement; fn: (e: Event) => void };
+    const handlers: H[] = [];
+
+    document.querySelectorAll<HTMLAnchorElement>('a[href^="#"]').forEach((a) => {
+      const fn = (e: Event) => {
+        const id = a.getAttribute("href")?.slice(1);
+        if (!id) return;
+        const target = document.getElementById(id);
+        if (!target) return;
+        e.preventDefault();
+        window.scrollTo({ top: target.getBoundingClientRect().top + window.scrollY - 72, behavior: "smooth" });
+      };
+      a.addEventListener("click", fn);
+      handlers.push({ el: a, fn });
+    });
+
+    return () => handlers.forEach(({ el, fn }) => el.removeEventListener("click", fn));
+  }, []);
+
+  /* ── CTA form submit ── */
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email) return;
+    setSending(true);
+    setErrMsg("");
+    try {
+      const res = await fetch("/api/auth/magic-link", {
+        method:  "POST",
+        headers: { "Content-Type": "application/json" },
+        body:    JSON.stringify({ email }),
+      });
+      if (res.ok) {
+        setSubmitted(true);
+      } else {
+        const data = await res.json().catch(() => ({})) as { error?: string };
+        setErrMsg(data.error ?? "エラーが発生しました。");
+      }
+    } catch {
+      setErrMsg("ネットワークエラーが発生しました。");
+    } finally {
+      setSending(false);
+    }
+  };
+
   return (
-    <div className="min-h-screen bg-[var(--paper)] font-sans">
-      {/* ── ナビゲーション ── */}
-      <header
-        className="sticky top-0 z-10 border-b border-[var(--rule)]"
-        style={{
-          background: "color-mix(in oklab, var(--paper) 92%, transparent)",
-          backdropFilter: "blur(10px)",
-        }}
-      >
-        <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-3">
-          <div className="flex items-center gap-2" style={{ fontWeight: 800, letterSpacing: "-0.02em" }}>
-            <span
-              className="brand-seal relative inline-flex h-[28px] w-[28px] items-center justify-center rounded-[8px] bg-[var(--ink)] text-white"
-              style={{
-                fontFamily: '"Noto Sans JP", serif',
-                fontWeight: 900,
-                fontSize: 16,
-                transform: "rotate(-4deg)",
-              }}
-              aria-hidden="true"
-            >
-              〆
-            </span>
-            <span className="text-[16px] text-[var(--ink)]">トラ</span>
+    <>
+      {/* ─── NAV ─── */}
+      <nav ref={navRef} className="lp-nav" id="nav">
+        <a href="#top" className="lp-nav-brand">
+          <span className="lp-nav-seal">〆</span>
+          <span>
+            SHIMETRA
+            <span style={{ color: "var(--ink-3)", marginLeft: 6, fontWeight: 500 }}>／〆トラ</span>
+          </span>
+        </a>
+        <div className="lp-nav-links">
+          <a href="#problem">課題</a>
+          <a href="#how">使い方</a>
+          <a href="#features">機能</a>
+          <a href="#voices">声</a>
+          <a href="#pricing">料金</a>
+        </div>
+        <a href="#cta" className="lp-nav-cta">
+          無料ではじめる <span className="arrow">→</span>
+        </a>
+      </nav>
+
+      {/* ─── HERO ─── */}
+      <header className="lp-hero" id="top">
+        <div className="lp-hero-grid">
+
+          {/* 左: コピー */}
+          <div className="lp-hero-left">
+            <div className="lp-eyebrow">
+              <span className="dot" />
+              2026 新卒 / 第二新卒 のための締切ノート
+            </div>
+
+            <h1 className="lp-hero-title">
+              <span className="line"><span className="word">出さなきゃ、を</span></span>
+              <span className="line"><span className="word"><em>出した</em>に。</span></span>
+              <span className="line"><span className="word"><span className="accent">〆トラ。</span></span></span>
+            </h1>
+
+            <p className="lp-hero-sub">
+              ES・説明会・面接の締切を一箇所に。<strong>72 / 24 / 3 時間前</strong>に、
+              〆トラがメールでそっと教えてくれる。スマホに余計なアプリは要らない、メール一通だけの安心。
+            </p>
+
+            <div className="lp-hero-cta-row">
+              <a href="#cta" className="lp-btn-magnet">
+                無料ではじめる <span className="arrow">→</span>
+              </a>
+              <a href="#how" className="lp-btn-ghost">仕組みを見る</a>
+            </div>
+
+            <div className="lp-hero-bullets">
+              <span className="lp-hero-bullet">アプリDL不要</span>
+              <span className="lp-hero-bullet">マジックリンク認証</span>
+              <span className="lp-hero-bullet">10件まで無料・広告なし</span>
+            </div>
           </div>
-          <Link
-            href="/login"
-            className="rounded-[10px] bg-[var(--ink)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand"
-          >
-            ログイン / 無料登録
-          </Link>
+
+          {/* 右: フォンモックアップ */}
+          <div className="lp-hero-right" ref={heroRightRef}>
+            <span className="lp-hero-mark" ref={heroMarkRef} aria-hidden="true">〆</span>
+
+            <div className="lp-hero-chip chip-1">
+              <span className="dot" />
+              <div>
+                <strong>残り 23:59:42</strong>
+                <span>ES ・ Recruit Holdings</span>
+              </div>
+            </div>
+
+            <div className="lp-hero-chip chip-3">
+              <span className="dot" />
+              <div>
+                <strong>提出完了</strong>
+                <span>freee ・ ES</span>
+              </div>
+            </div>
+
+            <div className="lp-hero-chip chip-2">
+              <span className="dot" />
+              <div>
+                <strong>メール通知 → 72h前</strong>
+                <span>メルカリ ・ 面接</span>
+              </div>
+            </div>
+
+            <div className="lp-phone" ref={phoneRef}>
+              <div className="lp-phone-notch" />
+              <div className="lp-phone-status">
+                <span>9:41</span>
+                <span className="right">●●●●● 5G ▮▮</span>
+              </div>
+              <div className="lp-phone-screen">
+                <div className="lp-phone-header">
+                  <div className="lp-phone-brand">
+                    <span className="seal">〆</span>〆トラ
+                  </div>
+                  <div className="lp-phone-icons">
+                    <span className="lp-phone-iconbtn">⌖<span className="pin">3</span></span>
+                    <span className="lp-phone-iconbtn">⚙</span>
+                  </div>
+                </div>
+                <div className="lp-phone-body">
+                  <div className="lp-phone-greeting">
+                    こんにちは、<span className="accent">悠真</span> さん。
+                  </div>
+                  <div className="lp-phone-hero">
+                    <div className="lbl">次の〆切まで</div>
+                    <div className="co">Recruit Holdings<span className="tag">ES</span></div>
+                    <div className="timer">
+                      <span className="seg"    ref={hourRef}>07</span><span className="unit">h</span>
+                      <span className="seg sm" ref={minRef}>17</span><span className="unit">m</span>
+                      <span className="seg sm" ref={secRef}>42</span><span className="unit">s</span>
+                    </div>
+                    <div className="bar"><div /></div>
+                  </div>
+                  <div className="lp-phone-list">
+                    <div className="lp-phone-item u-today">
+                      <span className="strip" />
+                      <span className="ring">7h</span>
+                      <div className="info">
+                        <span className="kind">ES</span>
+                        <div className="co">Recruit Holdings</div>
+                        <div className="meta">本日 17:30 まで</div>
+                      </div>
+                      <span className="pill">未対応</span>
+                    </div>
+                    <div className="lp-phone-item u-soon">
+                      <span className="strip" />
+                      <span className="ring">1d</span>
+                      <div className="info">
+                        <span className="kind k-interview">面接</span>
+                        <div className="co">メルカリ</div>
+                        <div className="meta">5/14 14:00</div>
+                      </div>
+                      <span className="pill">未対応</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="lp-scroll-cue">
+          SCROLL<span className="line" />
         </div>
       </header>
 
-      <main>
-        {/* ── Hero ── */}
-        <section className="mx-auto max-w-5xl px-6 py-20 lg:py-28">
-          <div className="lg:grid lg:grid-cols-2 lg:gap-16 lg:items-center">
-            {/* 左: テキスト */}
-            <motion.div
-              initial={fadeUp.initial}
-              animate={fadeUp.animate}
-              transition={fadeUp.transition}
-              className="stagger"
-            >
-              {/* 大きなシール */}
-              <div
-                className="big-seal relative mb-8 inline-flex h-[80px] w-[80px] items-center justify-center rounded-[20px] bg-[var(--ink)] text-white lg:h-[96px] lg:w-[96px] lg:rounded-[24px]"
-                style={{
-                  fontFamily: '"Noto Sans JP", serif',
-                  fontWeight: 900,
-                  fontSize: 48,
-                  letterSpacing: "-0.04em",
-                  transform: "rotate(-3deg)",
-                }}
-              >
-                〆
+      {/* ─── MARQUEE ─── */}
+      <section className="lp-marquee" aria-hidden="true">
+        <div className="lp-marquee-track">
+          {[...MARQUEE_ITEMS, ...MARQUEE_ITEMS].map(([big, small], i) => (
+            <span key={i} className="lp-marquee-item">
+              <span className="sep">〆</span>
+              <span>{big}</span>
+              <span className="small">{small}</span>
+            </span>
+          ))}
+        </div>
+      </section>
+
+      {/* ─── PROBLEM ─── */}
+      <section className="lp-problem" id="problem">
+        <div className="lp-problem-grid">
+          <div className="lp-problem-head" data-reveal="">
+            <div className="lp-eyebrow"><span className="dot" />就活で、いちばん怖いこと</div>
+            <h2>
+              「<span className="strike">うっかり</span>」で、<br />
+              志望企業を<br />
+              逃してませんか。
+            </h2>
+            <p>
+              志望度の高い企業ほど、ESも面接も日程が密集する。Excel・カレンダー・メール・
+              各社のマイページ、情報源がバラけるほど、いちばん大事な一行が抜け落ちる。
+            </p>
+          </div>
+
+          <div className="lp-stats-stack">
+            <div className="lp-stat-row" data-reveal="">
+              <div className="lp-stat-num" ref={stat82Ref}>
+                82<span className="pct">%</span>
               </div>
-
-              <h1
-                className="text-[40px] font-black text-[var(--ink)] leading-tight sm:text-[52px] lg:text-[56px]"
-                style={{ letterSpacing: "-0.035em" }}
-              >
-                締切ミスを、<br />
-                <span style={{ color: "var(--brand)" }}>もうしない。</span>
-              </h1>
-              <p className="mt-5 max-w-md text-[var(--ink-2)] leading-relaxed lg:text-lg">
-                ES・説明会・面接の締切を一元管理。<br />
-                締切前にメールで通知し、就活の出し忘れを防ぎます。
+              <p>
+                就活生が「締切を忘れて出せなかった経験がある／焦った経験がある」と回答。
+                <span className="src">SOURCE — 〆トラ ユーザーアンケート n=812</span>
               </p>
-
-              <div className="mt-8 flex flex-wrap gap-3">
-                <Link
-                  href="/login"
-                  className="rounded-[14px] bg-[var(--ink)] px-7 py-3.5 text-base font-bold text-[var(--paper)] transition-all hover:bg-brand hover:-translate-y-px"
-                  style={{ boxShadow: "0 8px 24px -8px rgba(15,13,26,0.4)" }}
-                >
-                  無料ではじめる
-                </Link>
-                <Link
-                  href="/login"
-                  className="rounded-[14px] border border-[var(--rule)] bg-[var(--card)] px-7 py-3.5 text-base font-semibold text-[var(--ink-2)] transition-all hover:border-[var(--ink-3)] hover:-translate-y-px"
-                >
-                  ログインする
-                </Link>
-              </div>
-              <p className="mt-4 text-sm text-[var(--ink-4)]">
-                クレジットカード不要 · 10件まで無料
+            </div>
+            <div className="lp-stat-row" data-reveal="">
+              <div className="lp-stat-num">3.4<span className="pct">件</span></div>
+              <p>
+                1人あたり、平均で同時並行して動いている選考の数。ピーク時は 10 件超。
+                <span className="src">SOURCE — 22-24卒 ヒアリング</span>
               </p>
-            </motion.div>
-
-            {/* 右: アプリプレビュー（デスクトップのみ） */}
-            <div className="hidden lg:block">
-              <AppPreview />
+            </div>
+            <div className="lp-stat-row" data-reveal="">
+              <div className="lp-stat-num">23<span className="pct">:59</span></div>
+              <p>
+                ES 締切の 6 割が「当日 23:59」設定。寝落ち1回が、就活ひとつを終わらせる。
+                <span className="src">SOURCE — 主要 50 社 採用ページ調査</span>
+              </p>
             </div>
           </div>
-        </section>
+        </div>
+      </section>
 
-        {/* ── こんな経験 ── */}
-        <section
-          className="border-y border-[var(--rule)] py-16 lg:py-20"
-          style={{ background: "var(--paper-2)" }}
-        >
-          <motion.div
-            initial={fadeUp.initial}
-            whileInView={fadeUp.animate}
-            viewport={{ once: true, margin: "-80px" }}
-            transition={fadeUp.transition}
-            className="mx-auto max-w-5xl px-6"
-          >
-            <p
-              className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--ink-4)] text-center"
-            >
-              THE PROBLEM
-            </p>
-            <h2
-              className="mt-3 text-center text-[28px] font-black text-[var(--ink)] lg:text-[34px]"
-              style={{ letterSpacing: "-0.025em" }}
-            >
-              こんな経験、ありませんか？
-            </h2>
-            <div className="mt-10 grid gap-4 sm:grid-cols-3">
-              {PROBLEMS.map(({ icon, text }) => (
-                <div
-                  key={text}
-                  className="rounded-[var(--radius-card)] border border-[var(--rule)] bg-[var(--card)] px-5 py-5 shadow-[var(--shadow-card)]"
-                >
-                  <span className="text-3xl">{icon}</span>
-                  <p className="mt-3 font-semibold text-[var(--ink)] leading-snug">{text}</p>
-                </div>
-              ))}
-            </div>
-          </motion.div>
-        </section>
+      {/* ─── HOW IT WORKS ─── */}
+      <section className="lp-how" id="how">
+        <div className="lp-how-head" data-reveal="">
+          <div className="lp-eyebrow"><span className="dot" />How it works ／ 3 STEPS</div>
+          <h2>メール一通で、<br /><em>締切を、見張る側に。</em></h2>
+          <p>アプリのダウンロードは要りません。マジックリンクでログインして、締切を3つ登録するだけ。</p>
+        </div>
 
-        {/* ── 使い方 ── */}
-        <section className="py-16 lg:py-24">
-          <motion.div
-            initial={fadeUp.initial}
-            whileInView={fadeUp.animate}
-            viewport={{ once: true, margin: "-80px" }}
-            transition={fadeUp.transition}
-            className="mx-auto max-w-5xl px-6"
-          >
-            <p
-              className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--ink-4)] text-center"
-            >
-              HOW IT WORKS
-            </p>
-            <h2
-              className="mt-3 text-center text-[28px] font-black text-[var(--ink)] lg:text-[34px]"
-              style={{ letterSpacing: "-0.025em" }}
-            >
-              3ステップで使い始める
-            </h2>
-            <div className="mt-10 grid gap-6 sm:grid-cols-3">
-              {HOW_STEPS.map(({ num, title, desc }) => (
-                <div key={num} className="flex flex-col gap-3">
-                  <span
-                    className="font-mono text-[32px] font-black text-[var(--ink-4)]"
-                    style={{ letterSpacing: "-0.04em" }}
-                  >
-                    {num}
-                  </span>
-                  <h3 className="text-base font-bold text-[var(--ink)]">{title}</h3>
-                  <p className="text-sm text-[var(--ink-3)] leading-relaxed">{desc}</p>
-                </div>
-              ))}
-            </div>
-          </motion.div>
-        </section>
-
-        {/* ── 料金プラン ── */}
-        <section
-          className="border-y border-[var(--rule)] py-16 lg:py-24"
-          style={{ background: "var(--paper-2)" }}
-        >
-          <motion.div
-            initial={fadeUp.initial}
-            whileInView={fadeUp.animate}
-            viewport={{ once: true, margin: "-80px" }}
-            transition={fadeUp.transition}
-            className="mx-auto max-w-5xl px-6"
-          >
-            <p
-              className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--ink-4)] text-center"
-            >
-              PRICING
-            </p>
-            <h2
-              className="mt-3 text-center text-[28px] font-black text-[var(--ink)] lg:text-[34px]"
-              style={{ letterSpacing: "-0.025em" }}
-            >
-              シンプルな料金プラン
-            </h2>
-            <div className="mt-10 grid gap-5 sm:grid-cols-2 sm:max-w-2xl sm:mx-auto">
-              {/* Free */}
-              <div className="rounded-[var(--radius-card)] border border-[var(--rule)] bg-[var(--card)] p-7 shadow-[var(--shadow-card)]">
-                <p
-                  className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--ink-4)]"
-                >
-                  FREE
-                </p>
-                <p
-                  className="mt-2 text-[38px] font-black text-[var(--ink)]"
-                  style={{ letterSpacing: "-0.03em" }}
-                >
-                  ¥0
-                  <span className="text-base font-normal text-[var(--ink-4)]">/月</span>
-                </p>
-                <p className="mt-0.5 text-sm text-[var(--ink-4)]">ずっと無料</p>
-                <ul className="mt-6 space-y-2.5">
-                  {FREE_FEATURES.map((f) => (
-                    <li key={f} className="flex items-start gap-2 text-sm text-[var(--ink-2)]">
-                      <span className="mt-0.5 text-[var(--s-done)] font-bold">✓</span>
-                      <span>{f}</span>
-                    </li>
-                  ))}
-                </ul>
-                <Link
-                  href="/login"
-                  className="mt-7 block rounded-[12px] border border-[var(--rule)] px-4 py-3 text-center text-sm font-semibold text-[var(--ink-2)] transition-colors hover:border-[var(--ink-3)] hover:bg-[var(--paper-2)]"
-                >
-                  無料ではじめる
-                </Link>
+        <div className="lp-how-steps">
+          <article className="lp-step" data-reveal="">
+            <div className="lp-step-num">STEP / 01 <span className="arrow">→</span></div>
+            <h3>大学のメールで、マジックリンク認証。</h3>
+            <p>パスワードもアプリも不要。〆トラから届くワンタップのリンクで、すぐにダッシュボードへ。</p>
+            <div className="lp-step-visual">
+              <div className="lp-sv-email">
+                <span className="at">⌗</span>
+                <span>you@university.ac.<span className="ing">jp</span></span>
               </div>
-
-              {/* Pro */}
-              <div
-                className="rounded-[var(--radius-card)] p-7 text-white relative overflow-hidden"
-                style={{
-                  background: "var(--ink)",
-                  boxShadow: "var(--shadow-pop)",
-                }}
-              >
-                <span
-                  className="pointer-events-none absolute right-[-20px] bottom-[-50px] select-none leading-none font-black"
-                  style={{
-                    color: "rgba(255,255,255,0.05)",
-                    fontFamily: '"Noto Sans JP", serif',
-                    fontSize: 160,
-                    lineHeight: 1,
-                  }}
-                  aria-hidden="true"
-                >
-                  〆
-                </span>
-                <div className="flex items-center justify-between">
-                  <p
-                    className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-white/60"
-                  >
-                    PRO
-                  </p>
-                  <span className="rounded-full bg-brand/30 px-2.5 py-0.5 text-[11px] font-semibold text-brand-light">
-                    おすすめ
-                  </span>
-                </div>
-                <p
-                  className="mt-2 text-[38px] font-black"
-                  style={{ letterSpacing: "-0.03em" }}
-                >
-                  ¥980
-                  <span className="text-base font-normal text-white/50">/月</span>
-                </p>
-                <p className="mt-0.5 text-sm text-white/50">税込</p>
-                <ul className="mt-6 space-y-2.5">
-                  {PRO_FEATURES.map((f) => (
-                    <li key={f} className="flex items-start gap-2 text-sm text-white/80">
-                      <span className="mt-0.5 font-bold text-brand-light">✓</span>
-                      <span>{f}</span>
-                    </li>
-                  ))}
-                </ul>
-                <Link
-                  href="/login"
-                  className="relative z-10 mt-7 block rounded-[12px] bg-brand px-4 py-3 text-center text-sm font-bold text-white transition-colors hover:bg-brand-hover"
-                >
-                  Pro ではじめる
-                </Link>
+              <div className="lp-sv-link">
+                <span className="lbl">From / 〆トラ ・ INBOX</span>
+                <span className="seal">〆</span>
+                <span className="ttl">マジックリンクでログイン</span>
+                <span className="desc">このリンクは 30 分間有効です。</span>
               </div>
             </div>
-          </motion.div>
-        </section>
+          </article>
 
-        {/* ── CTA ── */}
-        <section className="py-20 lg:py-28">
-          <motion.div
-            initial={fadeUp.initial}
-            whileInView={fadeUp.animate}
-            viewport={{ once: true, margin: "-80px" }}
-            transition={fadeUp.transition}
-            className="mx-auto max-w-xl px-6 text-center"
-          >
-            <h2
-              className="text-[28px] font-black text-[var(--ink)] lg:text-[34px]"
-              style={{ letterSpacing: "-0.025em" }}
+          <article className="lp-step" data-reveal="">
+            <div className="lp-step-num">STEP / 02 <span className="arrow">→</span></div>
+            <h3>締切を、3 タップで登録。</h3>
+            <p>企業名・種別・日時。種別はタイル選択、日時は「今夜23:59」などのクイックボタンから。</p>
+            <div className="lp-step-visual">
+              <div className="lp-sv-form">
+                <div className="lp-sv-field">
+                  <span className="k">COMPANY</span>
+                  メルカリ
+                </div>
+                <div className="lp-sv-tiles">
+                  <div className="lp-sv-tile">
+                    <span className="ic">ES</span>
+                    <span className="nm">ES</span>
+                    <span className="dt">エントリー</span>
+                  </div>
+                  <div className="lp-sv-tile on">
+                    <span className="ic">面</span>
+                    <span className="nm">面接</span>
+                    <span className="dt">5/14 14:00</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </article>
+
+          <article className="lp-step" data-reveal="">
+            <div className="lp-step-num">STEP / 03 <span className="arrow">→</span></div>
+            <h3>72/24/3 時間前に、メール通知。</h3>
+            <p>常駐するアプリも、鳴り続けるプッシュもなし。受信箱に、3 通の静かなリマインド。</p>
+            <div className="lp-step-visual">
+              <div className="lp-sv-notif-stack">
+                <div className="lp-sv-notif">
+                  <span className="ic">〆</span>
+                  <div>
+                    <div className="row"><span>72H前</span><span>3日前</span></div>
+                    <div className="ttl">メルカリ 面接まで残り 72 時間</div>
+                    <div className="desc">そろそろ準備をはじめましょう。</div>
+                  </div>
+                </div>
+                <div className="lp-sv-notif">
+                  <span className="ic">〆</span>
+                  <div>
+                    <div className="row"><span>24H前</span><span>1日前</span></div>
+                    <div className="ttl">残り 24 時間です</div>
+                    <div className="desc">志望動機を最終確認しましょう。</div>
+                  </div>
+                </div>
+                <div className="lp-sv-notif urgent">
+                  <span className="ic">〆</span>
+                  <div>
+                    <div className="row"><span>3H前</span><span>もうすぐ</span></div>
+                    <div className="ttl">あと 3 時間で締切です。</div>
+                    <div className="desc">最後の一通、出してから寝ましょう。</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      {/* ─── URGENCY ─── */}
+      <section className="lp-urgency" id="urgency">
+        <div className="lp-urgency-head">
+          <div data-reveal="">
+            <div className="lp-eyebrow"><span className="dot" />緊急度 ・ 4 階調</div>
+            <h2>色が、<em>時間の温度</em>を教える。</h2>
+          </div>
+          <p data-reveal="">
+            締切までの残り時間で、自動的に色が変わります。赤＝期限切れ、橙＝当日、黄＝3日以内、紺＝通常。
+            円形プログレスは、〆切までの「容量」が埋まっていく感覚を表現します。
+          </p>
+        </div>
+
+        <div className="lp-urg-grid">
+          {URG_CARDS.map(({ cls, off, label, title, desc, n, u }) => (
+            <div
+              key={cls}
+              className={`lp-urg-card ${cls}`}
+              style={{ "--off": off } as React.CSSProperties}
+              data-reveal=""
             >
-              まず無料で試してみる
-            </h2>
-            <p className="mt-4 text-[var(--ink-3)]">
-              登録はメールアドレスだけ。30秒ではじめられます。
-            </p>
+              <div>
+                <div className="lbl">{label}</div>
+                <h3>{title}</h3>
+                <p>{desc}</p>
+              </div>
+              <div className="lp-urg-ring">
+                <svg viewBox="0 0 120 120">
+                  <circle className="bg" cx="60" cy="60" r="51" fill="none" strokeWidth="8" />
+                  <circle className="fg" cx="60" cy="60" r="51" />
+                </svg>
+                <div className="center">
+                  <span className="n">{n}</span>
+                  <span className="u">{u}</span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ─── FEATURES (bento) ─── */}
+      <section className="lp-features" id="features">
+        <div className="lp-features-head" data-reveal="">
+          <div className="lp-eyebrow"><span className="dot" />FEATURES ／ 機能</div>
+          <h2>必要なことだけ、<br />美しく。</h2>
+        </div>
+
+        <div className="lp-bento">
+          <article className="lp-bento-cell b-1">
+            <div>
+              <span className="lp-b-icon">〆</span>
+              <h3>巨大カウントダウン。<br />次の〆切に、視線を集中。</h3>
+              <p>ダッシュボードの主役は、いつだって「次の一件」。残り時間を最大の文字で。</p>
+            </div>
+            <div>
+              <div className="lp-b1-visual">
+                <div className="lp-timer-big" ref={b1TimerRef}>
+                  07<span className="unit">d</span>
+                </div>
+                <div className="lp-timer-meta">
+                  <div className="k">NEXT ／ 次の締切</div>
+                  <div className="v">Recruit ・ ES</div>
+                </div>
+              </div>
+              <div className="lp-timer-bar"><div /></div>
+            </div>
+          </article>
+
+          <article className="lp-bento-cell b-2">
+            <span className="lp-b-icon">⌗</span>
+            <h3>ワンタップ・ステータス更新。</h3>
+            <p>カードのピルをタップで「未対応→提出済→完了」を循環。手数は最小。</p>
+            <div className="lp-schedule" aria-hidden="true">
+              <span>未対応</span><span>提出済</span><span>完了</span><span>辞退</span>
+            </div>
+          </article>
+
+          <article className="lp-bento-cell b-3">
+            <span className="lp-b-icon">⌘</span>
+            <h3>4 種類の選考、ぜんぶ。</h3>
+            <p>エントリーシート・説明会・面接・その他。色とアイコンで、瞬時に見分ける。</p>
+            <div className="lp-kinds-row">
+              <span className="k k-es">ES</span>
+              <span className="k k-brief">説明会</span>
+              <span className="k k-itv">面接</span>
+              <span className="k k-other">その他</span>
+            </div>
+          </article>
+
+          <article className="lp-bento-cell b-4">
+            <span className="lp-b-icon">∞</span>
+            <h3>クイック日時。</h3>
+            <p>「今夜23:59」「明日朝9時」「3日後」。よくあるパターンを、1 タップで。</p>
+          </article>
+
+          <article className="lp-bento-cell b-5">
+            <span className="lp-b-icon">◐</span>
+            <h3>紙 / 墨、2 テーマ。</h3>
+            <p>紙の温かみとも、深夜の墨ともつき合える。アクセントは 4 色から。</p>
+            <div className="lp-theme-swatches">
+              <span className="s1" /><span className="s2" /><span className="s3" /><span className="s4" />
+            </div>
+          </article>
+
+          <article className="lp-bento-cell b-6">
+            <span className="lp-b-icon">⌖</span>
+            <h3>メール通知 ・ 72/24/3h。</h3>
+            <p>プッシュ通知ではなく、メール。受信箱を就活の作戦本部に。</p>
+            <div className="lp-schedule">
+              <span>72h</span><span>24h</span><span>3h</span>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      {/* ─── VOICES ─── */}
+      <section className="lp-voices" id="voices">
+        <div className="lp-voices-head">
+          <div data-reveal="">
+            <div className="lp-eyebrow"><span className="dot" />VOICES ／ ユーザーの声</div>
+            <h2>「もっと早く<br />使いたかった。」</h2>
+          </div>
+          <p data-reveal="">
+            26卒・第二新卒の利用者ヒアリングから。締切の取り逃しが消えた、という声が最も多く寄せられました。
+          </p>
+        </div>
+
+        <div className="lp-voice-grid">
+          <div className="lp-voice" data-reveal="">
+            <div className="quote-mark">&quot;</div>
+            <blockquote>
+              ES の <em>23:59 締切</em>を、寝落ちで逃すのが本当に怖かった。
+              通知が3回飛んでくるから、夜中でも気づける。
+            </blockquote>
+            <div className="who">
+              <div className="avatar">悠</div>
+              <div className="meta">
+                <div className="nm">悠真 ・ 慶應 SFC</div>
+                <div className="role">26卒 ／ コンサル志望</div>
+              </div>
+            </div>
+          </div>
+
+          <div className="lp-voice" data-reveal="">
+            <div className="quote-mark">&quot;</div>
+            <blockquote>
+              Excel と Google カレンダーを行き来していたのが嘘みたい。
+              〆トラを開けば <em>「次の一件」</em>が最初に見える。
+            </blockquote>
+            <div className="who">
+              <div className="avatar">愛</div>
+              <div className="meta">
+                <div className="nm">愛梨 ・ 早稲田 商</div>
+                <div className="role">26卒 ／ 商社志望</div>
+              </div>
+            </div>
+          </div>
+
+          <div className="lp-voice" data-reveal="">
+            <div className="quote-mark">&quot;</div>
+            <blockquote>
+              通知が <em>メール</em>なのが、いい。
+              スマホ通知に疲れている時期に、静かに教えてくれる。
+            </blockquote>
+            <div className="who">
+              <div className="avatar">蓮</div>
+              <div className="meta">
+                <div className="nm">蓮 ・ 一橋 経済</div>
+                <div className="role">第二新卒 ／ メーカー</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ─── PRICING ─── */}
+      <section className="lp-pricing" id="pricing">
+        <div className="lp-eyebrow"><span className="dot" />PRICING ／ 料金</div>
+        <h2>就活の最中に、<br />お財布を開かせない。</h2>
+
+        <div className="lp-price-cards" data-reveal="">
+          {/* Free */}
+          <div className="lp-price-card">
+            <span className="lp-plan-label">FREE ／ 無料プラン</span>
+            <div className="lp-price-tag">
+              <span className="y">¥</span>
+              <span className="n">0</span>
+              <span className="u">/ 月</span>
+            </div>
+            <div className="note">クレジットカード不要・広告なし</div>
+            <ul className="lp-price-list">
+              {FREE_LIST.map((f) => <li key={f}>{f}</li>)}
+            </ul>
+            <a
+              href="#cta"
+              className="lp-btn-magnet"
+              style={{ width: "100%", justifyContent: "center" }}
+            >
+              無料ではじめる <span className="arrow">→</span>
+            </a>
+          </div>
+
+          {/* Pro */}
+          <div className="lp-price-card featured">
+            <span className="lp-plan-label">
+              PRO ／ プロプラン
+              <span className="lp-price-badge">おすすめ</span>
+            </span>
+            <div className="lp-price-tag">
+              <span className="y">¥</span>
+              <span className="n">{PRO_PRICE_JPY}</span>
+              <span className="u">/ 月</span>
+            </div>
+            <div className="note">税込・いつでも解約可能</div>
+            <ul className="lp-price-list">
+              {PRO_LIST.map((f) => <li key={f}>{f}</li>)}
+            </ul>
             <Link
               href="/login"
-              className="mt-8 inline-block rounded-[14px] bg-[var(--ink)] px-10 py-4 text-base font-bold text-[var(--paper)] transition-all hover:bg-brand hover:-translate-y-px"
-              style={{ boxShadow: "0 12px 32px -8px rgba(15,13,26,0.4)" }}
+              className="lp-btn-magnet"
+              style={{ width: "100%", justifyContent: "center" }}
             >
-              無料登録はこちら →
+              Pro ではじめる <span className="arrow">→</span>
             </Link>
-          </motion.div>
-        </section>
-      </main>
-
-      {/* フッター */}
-      <footer className="border-t border-[var(--rule)] bg-[var(--paper-2)] py-6 text-center text-xs text-[var(--ink-4)]">
-        <nav className="space-x-4">
-          <Link href="/terms" className="hover:text-[var(--ink-2)] hover:underline">
-            利用規約
-          </Link>
-          <Link href="/privacy" className="hover:text-[var(--ink-2)] hover:underline">
-            プライバシーポリシー
-          </Link>
-          <Link href="/legal" className="hover:text-[var(--ink-2)] hover:underline">
-            特定商取引法に基づく表記
-          </Link>
-          <a href="mailto:support@shimetra.com" className="hover:text-[var(--ink-2)] hover:underline">
-            お問い合わせ
-          </a>
-        </nav>
-        <p className="mt-3">© 2026 〆トラ</p>
-      </footer>
-    </div>
-  );
-}
-
-function AppPreview() {
-  return (
-    <div
-      className="rounded-[22px] p-5 shadow-[var(--shadow-pop)] relative overflow-hidden"
-      style={{ background: "var(--ink)" }}
-    >
-      {/* 装飾 */}
-      <span
-        className="pointer-events-none absolute select-none leading-none font-black"
-        style={{
-          color: "rgba(255,255,255,0.04)",
-          fontFamily: '"Noto Sans JP", serif',
-          fontSize: 180,
-          right: -20,
-          bottom: -56,
-          lineHeight: 1,
-        }}
-        aria-hidden="true"
-      >
-        〆
-      </span>
-
-      <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-white/50">
-        NEXT DEADLINE
-      </p>
-      <div className="mt-2 flex items-end gap-1">
-        <span
-          className="font-mono text-[52px] font-black leading-none tabular-nums text-white"
-          style={{ letterSpacing: "-0.04em" }}
-        >
-          3
-        </span>
-        <span className="mb-1 text-lg font-semibold text-white/70">日</span>
-      </div>
-      <p className="mt-2 font-semibold text-white/80">株式会社テクノロジー</p>
-      <span className="mt-1 inline-block rounded-full bg-[#e9defb] px-2 py-0.5 text-[11px] font-semibold text-[#5b3a93]">
-        ES
-      </span>
-
-      <div className="mt-4 h-1.5 overflow-hidden rounded-full bg-white/20">
-        <div className="h-full w-[78%] origin-left rounded-full bg-white/80" />
-      </div>
-
-      {/* ミニカード一覧 */}
-      <div className="mt-5 space-y-2.5">
-        {[
-          { company: "〇〇商事", kind: "説明会", days: 7, klass: "bg-[#d8eef0] text-[#1f6168]" },
-          { company: "△△銀行", kind: "面接", days: 14, klass: "bg-[#fde0c8] text-[#a04316]" },
-        ].map(({ company, kind, days, klass }) => (
-          <div
-            key={company}
-            className="flex items-center gap-3 rounded-[14px] border border-white/8 bg-white/8 p-3"
-          >
-            <div className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-full bg-white/10">
-              <span className="font-mono text-sm font-bold text-white tabular-nums">{days}</span>
-            </div>
-            <div className="min-w-0 flex-1">
-              <p className="truncate text-sm font-semibold text-white">{company}</p>
-              <span className={`mt-0.5 inline-block rounded-[4px] px-1.5 py-0.5 text-[10px] font-bold ${klass}`}>
-                {kind}
-              </span>
-            </div>
-            <span className="shrink-0 rounded-full bg-white/10 px-2.5 py-1 text-[10px] font-semibold text-white/60">
-              未対応
-            </span>
           </div>
-        ))}
-      </div>
-    </div>
+        </div>
+      </section>
+
+      {/* ─── CTA ─── */}
+      <section className="lp-cta" id="cta" ref={ctaSectionRef}>
+        <span className="lp-cta-mark" ref={ctaMarkRef} aria-hidden="true">〆</span>
+        <div className="lp-cta-inner">
+          <div className="lp-eyebrow"><span className="dot" />READY ／ あと、ひとつだけ。</div>
+          <h2>締切を、<br /><em>味方に</em>変える。</h2>
+          <p>メールアドレスを入れて、マジックリンクを受け取るだけ。30 秒で、ダッシュボードへ。</p>
+
+          {submitted ? (
+            <div className="lp-cta-sent">
+              ✓ メールを送信しました。受信箱をご確認ください。
+            </div>
+          ) : (
+            <form className="lp-cta-form" onSubmit={handleSubmit}>
+              <input
+                type="email"
+                placeholder="you@university.ac.jp"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+              <button type="submit" disabled={sending}>
+                {sending ? "送信中..." : <>マジックリンクを送る <span className="arrow">→</span></>}
+              </button>
+            </form>
+          )}
+          {errMsg && (
+            <p style={{ color: "var(--u-overdue)", marginTop: 12, fontSize: 14 }}>{errMsg}</p>
+          )}
+          <div className="lp-cta-foot">NO PASSWORDS ・ NO APP ・ NO ADS</div>
+        </div>
+      </section>
+
+      {/* ─── FOOTER ─── */}
+      <footer className="lp-footer">
+        <div className="lp-footer-inner">
+          <div className="brand">
+            <span className="seal">〆</span>
+            SHIMETRA ／ 〆トラ
+          </div>
+          <div className="links">
+            <Link href="/terms">利用規約</Link>
+            <Link href="/privacy">プライバシー</Link>
+            <Link href="/legal">特定商取引法</Link>
+            <a href="mailto:support@shimetra.com">お問い合わせ</a>
+          </div>
+          <div>© 2026 SHIMETRA · MADE WITH 〆</div>
+        </div>
+      </footer>
+    </>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { GtmScript } from "./_components/GtmScript";
 import { ConditionalHeader } from "./_components/ConditionalHeader";
+import { ConditionalFooter } from "./_components/ConditionalFooter";
 import { getSession } from "@/features/auth/session";
 import "./globals.css";
 
@@ -25,25 +25,7 @@ export default async function RootLayout({
         <GtmScript />
         {session && <ConditionalHeader email={session.email} />}
         <div className="flex-1">{children}</div>
-        <footer className="border-t border-[var(--rule)] bg-[var(--paper-2)] py-4 text-center text-xs text-[var(--ink-4)]">
-          <nav className="space-x-4">
-            <Link href="/terms" className="hover:underline">
-              利用規約
-            </Link>
-            <Link href="/privacy" className="hover:underline">
-              プライバシーポリシー
-            </Link>
-            <Link href="/legal" className="hover:underline">
-              特定商取引法に基づく表記
-            </Link>
-            <a
-              href="mailto:support@shimetra.com"
-              className="hover:underline"
-            >
-              お問い合わせ
-            </a>
-          </nav>
-        </footer>
+        <ConditionalFooter />
       </body>
     </html>
   );

--- a/src/app/lp.css
+++ b/src/app/lp.css
@@ -1,0 +1,811 @@
+/* ============================================================
+   〆トラ LP — editorial / kinetic
+   landing.html デザインの Next.js 実装用 CSS
+   :root は globals.css で定義済み
+   ============================================================ */
+
+html { scroll-behavior: smooth; }
+
+::selection { background: var(--ink); color: var(--paper); }
+
+/* ── shared ─────────────────────────────────────────────── */
+.lp-eyebrow {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+.lp-eyebrow .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--brand);
+  display: inline-block;
+}
+.lp-row-label {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+}
+
+/* ── nav ────────────────────────────────────────────────── */
+.lp-nav {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 32px;
+  background: color-mix(in oklab, var(--paper) 86%, transparent);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border-bottom: 1px solid transparent;
+  transition: border-color .3s, background .3s;
+}
+.lp-nav.scrolled { border-color: var(--rule); }
+.lp-nav-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  font-size: 16px;
+  color: var(--ink);
+  text-decoration: none;
+}
+.lp-nav-seal {
+  width: 30px; height: 30px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: "Noto Sans JP", serif;
+  font-weight: 900; font-size: 18px;
+  color: white; background: var(--ink);
+  border-radius: 8px;
+  transform: rotate(-4deg);
+  position: relative;
+  transition: transform .3s cubic-bezier(.2,.8,.2,1);
+}
+.lp-nav-seal::after {
+  content: "";
+  position: absolute; inset: 2px;
+  border: 1px solid rgba(255,255,255,0.18);
+  border-radius: 6px;
+}
+.lp-nav-brand:hover .lp-nav-seal { transform: rotate(12deg) scale(1.05); }
+.lp-nav-links {
+  display: flex; align-items: center; gap: 28px;
+}
+.lp-nav-links a {
+  font-size: 13px; font-weight: 500; color: var(--ink-2);
+  text-decoration: none; position: relative;
+}
+.lp-nav-links a::after {
+  content: "";
+  position: absolute; left: 0; right: 0; bottom: -4px;
+  height: 1px; background: var(--ink);
+  transform: scaleX(0); transform-origin: left;
+  transition: transform .35s cubic-bezier(.2,.8,.2,1);
+}
+.lp-nav-links a:hover::after { transform: scaleX(1); }
+.lp-nav-cta {
+  font-size: 13px; font-weight: 600;
+  padding: 9px 16px;
+  background: var(--ink); color: var(--paper);
+  border-radius: 999px;
+  display: inline-flex; align-items: center; gap: 6px;
+  text-decoration: none;
+  transition: transform .2s, background .2s;
+}
+.lp-nav-cta:hover { background: var(--brand); transform: translateY(-1px); }
+.lp-nav-cta .arrow { transition: transform .2s; }
+.lp-nav-cta:hover .arrow { transform: translateX(3px); }
+@media (max-width: 720px) { .lp-nav-links { display: none; } }
+
+/* ── hero ───────────────────────────────────────────────── */
+.lp-hero {
+  padding: 140px 32px 80px;
+  min-height: 100vh;
+  display: flex; align-items: center;
+  position: relative; overflow: hidden;
+}
+.lp-hero::before {
+  content: "";
+  position: absolute; inset: 0;
+  background:
+    radial-gradient(900px 600px at 12% 20%, rgba(79,70,229,0.10), transparent 60%),
+    radial-gradient(700px 500px at 90% 90%, rgba(233,101,28,0.07), transparent 60%);
+  pointer-events: none;
+}
+.lp-hero-grid {
+  position: relative; z-index: 2;
+  display: grid;
+  grid-template-columns: 1.15fr 0.85fr;
+  gap: 60px; align-items: center;
+  max-width: 1480px; margin: 0 auto; width: 100%;
+}
+@media (max-width: 980px) {
+  .lp-hero { padding-top: 110px; }
+  .lp-hero-grid { grid-template-columns: 1fr; gap: 40px; }
+}
+.lp-hero-left .lp-eyebrow { margin-bottom: 24px; }
+.lp-hero-title {
+  font-family: "Noto Sans JP", serif;
+  font-weight: 900;
+  font-size: clamp(48px, 7.4vw, 116px);
+  letter-spacing: -0.045em;
+  line-height: 0.95;
+  margin: 0; color: var(--ink);
+}
+.lp-hero-title .line { display: block; overflow: hidden; }
+.lp-hero-title .word {
+  display: inline-block;
+  transform: translateY(110%);
+  animation: lpTitleRise 1100ms cubic-bezier(.2,.8,.2,1) forwards;
+}
+.lp-hero-title .line:nth-child(1) .word { animation-delay: 60ms; }
+.lp-hero-title .line:nth-child(2) .word { animation-delay: 180ms; }
+.lp-hero-title .line:nth-child(3) .word { animation-delay: 300ms; }
+.lp-hero-title em {
+  font-style: normal; position: relative; white-space: nowrap;
+}
+.lp-hero-title em::after {
+  content: "";
+  position: absolute; left: -2%; right: -2%; bottom: 8%; height: 14%;
+  background: var(--u-today); z-index: -1;
+  transform-origin: left;
+  animation: lpUnderlineDraw 800ms 700ms cubic-bezier(.2,.8,.2,1) both;
+}
+.lp-hero-title .accent {
+  background: linear-gradient(95deg, var(--brand) 0%, #8b5cf6 55%, var(--u-today) 100%);
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+}
+.lp-hero-sub {
+  margin: 36px 0 0;
+  font-size: clamp(15px, 1.1vw, 17px);
+  line-height: 1.75; color: var(--ink-2); max-width: 46ch;
+  opacity: 0;
+  animation: lpFadeUp 700ms 900ms cubic-bezier(.2,.8,.2,1) forwards;
+}
+.lp-hero-cta-row {
+  margin-top: 36px;
+  display: flex; flex-wrap: wrap; align-items: center; gap: 14px;
+  opacity: 0;
+  animation: lpFadeUp 700ms 1050ms cubic-bezier(.2,.8,.2,1) forwards;
+}
+.lp-btn-magnet {
+  position: relative;
+  display: inline-flex; align-items: center; gap: 10px;
+  padding: 18px 28px; border-radius: 999px;
+  background: var(--ink); color: var(--paper);
+  font-weight: 600; font-size: 15px;
+  letter-spacing: -0.005em;
+  overflow: hidden; transition: background .2s;
+  isolation: isolate; text-decoration: none;
+}
+.lp-btn-magnet::before {
+  content: "";
+  position: absolute; inset: 0; background: var(--brand);
+  border-radius: inherit;
+  transform: translateY(101%);
+  transition: transform .5s cubic-bezier(.2,.8,.2,1);
+  z-index: -1;
+}
+.lp-btn-magnet:hover::before { transform: translateY(0); }
+.lp-btn-magnet .arrow {
+  display: inline-flex; width: 22px; height: 22px; border-radius: 50%;
+  background: var(--paper); color: var(--ink);
+  align-items: center; justify-content: center;
+  transition: transform .25s;
+}
+.lp-btn-magnet:hover .arrow { transform: rotate(-45deg); }
+.lp-btn-ghost {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 18px 4px; font-weight: 500; font-size: 14px;
+  color: var(--ink-2); text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color .2s, color .2s;
+}
+.lp-btn-ghost:hover { border-color: var(--ink); color: var(--ink); }
+.lp-hero-bullets {
+  margin-top: 44px; display: flex; flex-wrap: wrap; gap: 28px;
+  opacity: 0;
+  animation: lpFadeUp 700ms 1200ms cubic-bezier(.2,.8,.2,1) forwards;
+}
+.lp-hero-bullet {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 12px;
+  font-family: "JetBrains Mono", monospace;
+  letter-spacing: 0.08em; color: var(--ink-3); text-transform: uppercase;
+}
+.lp-hero-bullet::before {
+  content: ""; width: 6px; height: 6px; border-radius: 50%; background: var(--brand);
+}
+.lp-hero-bullet:nth-child(2)::before { background: var(--u-today); }
+.lp-hero-bullet:nth-child(3)::before { background: var(--s-done); }
+
+/* hero phone column */
+.lp-hero-right {
+  position: relative; display: flex;
+  justify-content: center; align-items: center;
+  perspective: 1400px;
+}
+.lp-hero-mark {
+  position: absolute;
+  font-family: "Noto Sans JP", serif;
+  font-weight: 900;
+  font-size: clamp(380px, 46vw, 760px);
+  line-height: 0.78; color: var(--ink); opacity: 0.05;
+  pointer-events: none; z-index: 0;
+  right: -8%; top: -8%;
+  letter-spacing: -0.06em; user-select: none;
+  transform: rotate(-6deg);
+}
+
+/* phone device */
+.lp-phone {
+  width: 340px; height: 720px;
+  border-radius: 42px;
+  background: var(--card);
+  box-shadow:
+    0 0 0 10px #0a0816,
+    0 0 0 12px rgba(255,255,255,0.04),
+    0 40px 120px -40px rgba(15,13,26,0.55),
+    0 80px 160px -80px rgba(79,70,229,0.4);
+  position: relative; overflow: hidden; z-index: 2;
+  transform: rotate(-3deg);
+  animation: lpPhoneFloat 7s ease-in-out infinite;
+}
+@keyframes lpPhoneFloat {
+  0%, 100% { transform: rotate(-3deg) translateY(0); }
+  50%      { transform: rotate(-3deg) translateY(-14px); }
+}
+.lp-phone-notch {
+  position: absolute; top: 12px; left: 50%; transform: translateX(-50%);
+  width: 100px; height: 26px;
+  background: #0a0816; border-radius: 999px; z-index: 60;
+}
+.lp-phone-status {
+  position: absolute; top: 16px; left: 28px; right: 28px; height: 22px;
+  display: flex; justify-content: space-between; align-items: center;
+  z-index: 50; font-family: "Inter", sans-serif; font-size: 13px; font-weight: 600;
+  color: var(--ink);
+}
+.lp-phone-status .right { display: flex; align-items: center; gap: 6px; }
+.lp-phone-screen {
+  position: absolute; inset: 0; padding-top: 50px;
+  background: var(--paper); display: flex; flex-direction: column; overflow: hidden;
+}
+.lp-phone-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 18px 12px;
+  border-bottom: 1px solid var(--rule);
+  background: color-mix(in oklab, var(--paper) 88%, transparent);
+}
+.lp-phone-brand {
+  display: flex; align-items: center; gap: 8px;
+  font-weight: 800; font-size: 15px;
+}
+.lp-phone-brand .seal {
+  width: 26px; height: 26px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: "Noto Sans JP", serif; font-weight: 900; font-size: 16px;
+  color: white; background: var(--ink); border-radius: 7px;
+  transform: rotate(-4deg);
+}
+.lp-phone-icons { display: flex; gap: 8px; }
+.lp-phone-iconbtn {
+  width: 30px; height: 30px; border-radius: 10px;
+  border: 1px solid var(--rule); background: var(--card);
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--ink-2); font-size: 14px; position: relative;
+}
+.lp-phone-iconbtn .pin {
+  position: absolute; top: -3px; right: -3px;
+  width: 14px; height: 14px;
+  background: var(--u-overdue); border: 2px solid var(--paper);
+  border-radius: 999px; font-size: 8px; font-weight: 700; color: white;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.lp-phone-body { padding: 16px 16px 0; overflow: hidden; flex: 1; }
+.lp-phone-greeting {
+  font-size: 18px; font-weight: 800; letter-spacing: -0.02em; color: var(--ink);
+}
+.lp-phone-greeting .accent { color: var(--brand); }
+.lp-phone-hero {
+  margin-top: 12px; border-radius: 18px;
+  background: var(--ink); color: #fff;
+  padding: 16px 16px 18px; position: relative; overflow: hidden;
+}
+.lp-phone-hero::before {
+  content: "〆"; position: absolute; right: -18px; bottom: -46px;
+  font-family: "Noto Sans JP", serif; font-size: 170px; font-weight: 900;
+  color: rgba(255,255,255,0.06); line-height: 1;
+}
+.lp-phone-hero .lbl {
+  font-family: "JetBrains Mono", monospace; font-size: 9px;
+  letter-spacing: 0.18em; text-transform: uppercase; color: rgba(255,255,255,0.6);
+}
+.lp-phone-hero .co { margin-top: 4px; font-size: 16px; font-weight: 800; letter-spacing: -0.02em; }
+.lp-phone-hero .co .tag {
+  display: inline-block; margin-left: 6px; padding: 2px 6px; border-radius: 5px;
+  background: rgba(255,255,255,0.14); font-size: 9px; font-weight: 600; vertical-align: middle;
+}
+.lp-phone-hero .timer {
+  margin-top: 14px; display: flex; align-items: baseline; gap: 4px;
+  font-variant-numeric: tabular-nums;
+}
+.lp-phone-hero .timer .seg { font-size: 38px; font-weight: 800; letter-spacing: -0.04em; line-height: 1; }
+.lp-phone-hero .timer .seg.sm { font-size: 22px; color: rgba(255,255,255,0.8); }
+.lp-phone-hero .timer .unit { font-size: 11px; color: rgba(255,255,255,0.6); margin: 0 4px 0 1px; font-weight: 500; }
+.lp-phone-hero .bar { margin-top: 14px; height: 5px; background: rgba(255,255,255,0.12); border-radius: 999px; overflow: hidden; position: relative; }
+.lp-phone-hero .bar > div {
+  position: absolute; inset: 0 30% 0 0;
+  background: linear-gradient(90deg, #fff, #ffb38a); border-radius: 999px;
+}
+.lp-phone-list { margin-top: 14px; display: flex; flex-direction: column; gap: 8px; }
+.lp-phone-item {
+  background: var(--card); border-radius: 14px; border: 1px solid var(--rule);
+  padding: 10px 12px; display: flex; align-items: center; gap: 12px;
+  position: relative; overflow: hidden;
+}
+.lp-phone-item .strip { position: absolute; left: 0; top: 0; bottom: 0; width: 3px; }
+.lp-phone-item.u-today .strip { background: var(--u-today); }
+.lp-phone-item.u-soon  .strip { background: var(--u-soon); }
+.lp-phone-item .ring {
+  width: 36px; height: 36px; border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 12px; font-weight: 800; letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums; flex-shrink: 0;
+}
+.lp-phone-item.u-today .ring { background: var(--u-today-bg); color: var(--u-today); }
+.lp-phone-item.u-soon  .ring { background: var(--u-soon-bg);  color: var(--u-soon); }
+.lp-phone-item .info { flex: 1; min-width: 0; }
+.lp-phone-item .kind {
+  font-family: "JetBrains Mono", monospace; font-size: 9px; font-weight: 700;
+  letter-spacing: 0.04em; padding: 1px 5px; border-radius: 3px;
+  background: #e9defb; color: #5b3a93; display: inline-block;
+}
+.lp-phone-item .kind.k-interview { background: #fde0c8; color: #a04316; }
+.lp-phone-item .co { font-size: 13px; font-weight: 700; margin-top: 3px; letter-spacing: -0.01em; color: var(--ink); }
+.lp-phone-item .meta { margin-top: 2px; font-family: "JetBrains Mono", monospace; font-size: 10px; color: var(--ink-3); }
+.lp-phone-item .pill { font-size: 9px; font-weight: 700; padding: 4px 8px; border-radius: 999px; background: var(--paper-2); color: var(--ink-2); }
+
+/* hero floating chips */
+.lp-hero-chip {
+  position: absolute; background: var(--card); border: 1px solid var(--rule);
+  border-radius: 14px; padding: 10px 14px;
+  box-shadow: 0 20px 40px -20px rgba(15,13,26,0.25);
+  z-index: 3; display: flex; align-items: center; gap: 10px; font-size: 12px;
+  animation: lpChipFloat 6s ease-in-out infinite;
+}
+.lp-hero-chip .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--u-overdue); position: relative; }
+.lp-hero-chip .dot::after {
+  content: ""; position: absolute; inset: 0; border-radius: 50%; background: var(--u-overdue);
+  animation: lpPingDot 1.6s ease-out infinite;
+}
+.lp-hero-chip strong { font-weight: 700; color: var(--ink); }
+.lp-hero-chip span { color: var(--ink-3); font-family: "JetBrains Mono", monospace; font-size: 10px; }
+.lp-hero-chip.chip-1 { top: 12%; left: -8%; }
+.lp-hero-chip.chip-2 { bottom: 14%; right: -6%; animation-delay: 2s; }
+.lp-hero-chip.chip-3 { top: 50%; left: -14%; animation-delay: 1s; }
+.lp-hero-chip.chip-3 .dot { background: var(--s-done); }
+.lp-hero-chip.chip-3 .dot::after { display: none; }
+@media (max-width: 980px) {
+  .lp-hero-chip.chip-1 { left: 6%; top: 6%; }
+  .lp-hero-chip.chip-2 { right: 6%; bottom: 6%; }
+  .lp-hero-chip.chip-3 { display: none; }
+}
+
+/* scroll cue */
+.lp-scroll-cue {
+  position: absolute; bottom: 30px; left: 50%; transform: translateX(-50%);
+  font-family: "JetBrains Mono", monospace; font-size: 10px;
+  letter-spacing: 0.2em; text-transform: uppercase; color: var(--ink-3);
+  display: flex; flex-direction: column; align-items: center; gap: 8px;
+  opacity: 0; animation: lpFadeUp 700ms 1400ms cubic-bezier(.2,.8,.2,1) forwards;
+  z-index: 4;
+}
+.lp-scroll-cue .line {
+  width: 1px; height: 36px;
+  background: linear-gradient(to bottom, var(--ink-3), transparent);
+  animation: lpScrollLine 2.2s ease-in-out infinite; transform-origin: top;
+}
+
+/* ── marquee band ──────────────────────────────────────── */
+.lp-marquee {
+  background: var(--ink); color: var(--paper);
+  padding: 26px 0; overflow: hidden;
+  border-top: 1px solid rgba(255,255,255,0.05);
+  border-bottom: 1px solid rgba(255,255,255,0.05);
+  position: relative;
+}
+.lp-marquee-track {
+  display: flex; gap: 56px; white-space: nowrap;
+  animation: lpMarqueeScroll 28s linear infinite; width: max-content;
+}
+.lp-marquee-item {
+  display: inline-flex; align-items: center; gap: 56px;
+  font-family: "Noto Sans JP", serif; font-weight: 800;
+  font-size: clamp(38px, 5vw, 64px); letter-spacing: -0.03em;
+}
+.lp-marquee-item .sep { font-family: "Noto Sans JP", serif; color: var(--u-today); font-weight: 900; font-size: 0.9em; }
+.lp-marquee-item .small {
+  font-family: "JetBrains Mono", monospace; font-size: 13px;
+  letter-spacing: 0.15em; text-transform: uppercase; font-weight: 500;
+  color: rgba(255,255,255,0.55);
+}
+
+/* ── problem / pain section ──────────────────────────────── */
+.lp-problem {
+  padding: 140px 32px;
+  background: var(--paper); position: relative;
+}
+.lp-problem-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 80px; align-items: flex-start;
+  max-width: 1280px; margin: 0 auto;
+}
+@media (max-width: 880px) { .lp-problem-grid { grid-template-columns: 1fr; gap: 40px; } }
+.lp-problem-head h2 {
+  margin: 16px 0 0; font-family: "Noto Sans JP", serif; font-weight: 900;
+  font-size: clamp(36px, 4.5vw, 64px); letter-spacing: -0.035em; line-height: 1.1; color: var(--ink);
+}
+.lp-problem-head h2 .strike { position: relative; display: inline-block; }
+.lp-problem-head h2 .strike::after {
+  content: ""; position: absolute; left: -4%; right: -4%; top: 52%;
+  height: 4px; background: var(--u-overdue);
+  transform: scaleX(0); transform-origin: left;
+  transition: transform 1s cubic-bezier(.2,.8,.2,1);
+}
+.lp-problem-head.in-view h2 .strike::after { transform: scaleX(1); }
+.lp-problem-head p { margin: 28px 0 0; font-size: 16px; line-height: 1.8; color: var(--ink-2); max-width: 42ch; }
+.lp-stats-stack { display: flex; flex-direction: column; gap: 0; }
+.lp-stat-row {
+  padding: 28px 0; border-top: 1px solid rgba(15,13,26,0.14);
+  display: grid; grid-template-columns: 1fr 1fr; align-items: end; gap: 24px;
+  opacity: 0; transform: translateY(20px);
+  transition: opacity .8s cubic-bezier(.2,.8,.2,1), transform .8s cubic-bezier(.2,.8,.2,1);
+}
+.lp-stat-row.in-view { opacity: 1; transform: translateY(0); }
+.lp-stat-row:last-child { border-bottom: 1px solid rgba(15,13,26,0.14); }
+.lp-stat-num {
+  font-family: "Noto Sans JP", serif; font-weight: 900;
+  font-size: clamp(64px, 8vw, 130px); letter-spacing: -0.05em; line-height: 1;
+  color: var(--ink); font-variant-numeric: tabular-nums;
+}
+.lp-stat-num .pct { font-size: 0.45em; color: var(--ink-3); margin-left: 4px; }
+.lp-stat-row p { margin: 0; font-size: 14px; line-height: 1.7; color: var(--ink-2); }
+.lp-stat-row .src {
+  font-family: "JetBrains Mono", monospace; font-size: 10px; color: var(--ink-4);
+  letter-spacing: 0.1em; display: block; margin-top: 8px; text-transform: uppercase;
+}
+
+/* ── how it works ─────────────────────────────────────── */
+.lp-how {
+  padding: 140px 0; background: var(--ink); color: var(--paper);
+  position: relative; overflow: hidden;
+}
+.lp-how-head {
+  text-align: center; max-width: 720px; margin: 0 auto 100px; padding: 0 32px;
+}
+.lp-how-head .lp-eyebrow { color: rgba(255,255,255,0.6); }
+.lp-how-head .lp-eyebrow .dot { background: var(--u-today); }
+.lp-how-head h2 {
+  margin: 18px 0 0; font-family: "Noto Sans JP", serif; font-weight: 900;
+  font-size: clamp(38px, 5vw, 70px); letter-spacing: -0.04em; line-height: 1.05;
+}
+.lp-how-head h2 em { font-style: normal; color: var(--u-today); }
+.lp-how-head p { margin: 22px auto 0; font-size: 16px; line-height: 1.7; color: rgba(255,255,255,0.7); max-width: 44ch; }
+.lp-how-steps {
+  max-width: 1280px; margin: 0 auto; padding: 0 32px;
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 32px; align-items: stretch;
+}
+@media (max-width: 880px) { .lp-how-steps { grid-template-columns: 1fr; gap: 40px; } }
+.lp-step {
+  position: relative; border-top: 1px solid rgba(255,255,255,0.16); padding-top: 28px;
+  opacity: 0; transform: translateY(28px);
+  transition: opacity .9s cubic-bezier(.2,.8,.2,1), transform .9s cubic-bezier(.2,.8,.2,1);
+}
+.lp-step.in-view { opacity: 1; transform: translateY(0); }
+.lp-step:nth-child(2) { transition-delay: 140ms; }
+.lp-step:nth-child(3) { transition-delay: 280ms; }
+.lp-step-num {
+  font-family: "JetBrains Mono", monospace; font-size: 12px; letter-spacing: 0.16em;
+  color: rgba(255,255,255,0.5); display: flex; align-items: center; justify-content: space-between;
+}
+.lp-step-num .arrow {
+  width: 22px; height: 22px; border-radius: 50%;
+  background: rgba(255,255,255,0.06);
+  display: inline-flex; align-items: center; justify-content: center;
+  color: rgba(255,255,255,0.8); font-size: 11px;
+  transition: background .2s, transform .25s;
+}
+.lp-step:hover .lp-step-num .arrow { background: var(--u-today); color: var(--ink); transform: rotate(-45deg); }
+.lp-step h3 { margin: 14px 0 0; font-family: "Noto Sans JP", serif; font-weight: 800; font-size: 28px; letter-spacing: -0.025em; line-height: 1.2; }
+.lp-step p { margin: 16px 0 0; font-size: 14px; line-height: 1.7; color: rgba(255,255,255,0.65); }
+.lp-step-visual {
+  margin-top: 28px; background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.08); border-radius: 18px;
+  padding: 22px; position: relative; overflow: hidden; aspect-ratio: 1.1 / 1;
+}
+
+/* step 1 visual */
+.lp-sv-email {
+  display: flex; align-items: center; background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.12); border-radius: 10px;
+  padding: 11px 12px; font-family: "JetBrains Mono", monospace; font-size: 12px; gap: 8px;
+}
+.lp-sv-email .at { color: rgba(255,255,255,0.4); }
+.lp-sv-email .ing { border-right: 1px solid var(--paper); animation: lpCaret 1s steps(2) infinite; }
+.lp-sv-link {
+  margin-top: 14px; padding: 18px; border-radius: 14px;
+  background: linear-gradient(135deg, rgba(79,70,229,0.16), rgba(233,101,28,0.12));
+  border: 1px solid rgba(255,255,255,0.08);
+  display: flex; flex-direction: column; align-items: flex-start; gap: 10px;
+}
+.lp-sv-link .lbl { font-family: "JetBrains Mono", monospace; font-size: 9px; letter-spacing: 0.16em; text-transform: uppercase; color: rgba(255,255,255,0.6); }
+.lp-sv-link .seal { width: 40px; height: 40px; border-radius: 10px; background: var(--paper); color: var(--ink); display: inline-flex; align-items: center; justify-content: center; font-family: "Noto Sans JP", serif; font-weight: 900; font-size: 22px; transform: rotate(-4deg); }
+.lp-sv-link .ttl { font-size: 14px; font-weight: 700; }
+.lp-sv-link .desc { font-size: 11px; color: rgba(255,255,255,0.6); }
+
+/* step 2 visual */
+.lp-sv-form { display: flex; flex-direction: column; gap: 10px; }
+.lp-sv-field { background: rgba(255,255,255,0.05); border-radius: 10px; padding: 8px 10px; font-size: 11px; font-family: "JetBrains Mono", monospace; letter-spacing: 0.04em; color: rgba(255,255,255,0.8); }
+.lp-sv-field .k { font-size: 9px; letter-spacing: 0.2em; color: rgba(255,255,255,0.45); text-transform: uppercase; display: block; }
+.lp-sv-tiles { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-top: 4px; }
+.lp-sv-tile { padding: 12px 10px; border-radius: 10px; background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); display: flex; flex-direction: column; gap: 4px; }
+.lp-sv-tile.on { background: var(--paper); color: var(--ink); border-color: var(--paper); }
+.lp-sv-tile .ic { width: 22px; height: 22px; border-radius: 6px; background: rgba(255,255,255,0.1); display: inline-flex; align-items: center; justify-content: center; font-family: "JetBrains Mono", monospace; font-size: 10px; font-weight: 700; }
+.lp-sv-tile.on .ic { background: var(--u-today); color: white; }
+.lp-sv-tile .nm { font-size: 12px; font-weight: 700; }
+.lp-sv-tile .dt { font-family: "JetBrains Mono", monospace; font-size: 9px; color: rgba(255,255,255,0.4); letter-spacing: 0.04em; }
+.lp-sv-tile.on .dt { color: var(--ink-3); }
+
+/* step 3 visual */
+.lp-sv-notif-stack { display: flex; flex-direction: column; gap: 8px; position: relative; }
+.lp-sv-notif { background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); border-radius: 12px; padding: 10px 12px; display: flex; gap: 10px; align-items: flex-start; }
+.lp-sv-notif .ic { width: 28px; height: 28px; border-radius: 7px; background: var(--paper); color: var(--ink); font-family: "Noto Sans JP", serif; font-weight: 900; font-size: 15px; display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; }
+.lp-sv-notif .row { display: flex; justify-content: space-between; font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: rgba(255,255,255,0.5); }
+.lp-sv-notif .ttl { font-size: 12px; font-weight: 700; margin-top: 3px; }
+.lp-sv-notif .desc { font-size: 10px; color: rgba(255,255,255,0.55); margin-top: 2px; line-height: 1.5; }
+.lp-sv-notif.urgent { border-color: rgba(233,101,28,0.35); background: rgba(233,101,28,0.08); }
+.lp-sv-notif.urgent .ic { background: var(--u-today); color: white; }
+
+/* ── urgency demo ─────────────────────────────────────────── */
+.lp-urgency { padding: 140px 32px; }
+.lp-urgency-head {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 60px; align-items: end;
+  max-width: 1280px; margin: 0 auto 60px;
+}
+@media (max-width: 880px) { .lp-urgency-head { grid-template-columns: 1fr; gap: 24px; } }
+.lp-urgency-head h2 { margin: 14px 0 0; font-family: "Noto Sans JP", serif; font-weight: 900; font-size: clamp(36px, 4.5vw, 64px); letter-spacing: -0.035em; line-height: 1.1; }
+.lp-urgency-head h2 em { font-style: normal; background: linear-gradient(95deg, var(--u-overdue) 0%, var(--u-today) 50%, var(--brand) 100%); -webkit-background-clip: text; background-clip: text; color: transparent; }
+.lp-urgency-head p { font-size: 15px; line-height: 1.8; color: var(--ink-2); max-width: 44ch; margin: 0; }
+.lp-urg-grid { max-width: 1280px; margin: 0 auto; display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
+@media (max-width: 1000px) { .lp-urg-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 560px)  { .lp-urg-grid { grid-template-columns: 1fr; } }
+.lp-urg-card {
+  border-radius: 22px; padding: 28px; background: var(--card); border: 1px solid var(--rule);
+  position: relative; overflow: hidden; min-height: 320px;
+  display: flex; flex-direction: column; justify-content: space-between;
+  opacity: 0; transform: translateY(28px);
+  transition: opacity .9s cubic-bezier(.2,.8,.2,1), transform .9s cubic-bezier(.2,.8,.2,1), box-shadow .3s;
+}
+.lp-urg-card.in-view { opacity: 1; transform: translateY(0); }
+.lp-urg-card:nth-child(2) { transition-delay: 100ms; }
+.lp-urg-card:nth-child(3) { transition-delay: 200ms; }
+.lp-urg-card:nth-child(4) { transition-delay: 300ms; }
+.lp-urg-card:hover { transform: translateY(-6px); box-shadow: 0 30px 60px -30px rgba(15,13,26,0.3); }
+.lp-urg-card.overdue { background: var(--u-overdue-bg); border-color: rgba(210,58,58,0.2); }
+.lp-urg-card.today   { background: var(--u-today-bg);   border-color: rgba(233,101,28,0.22); }
+.lp-urg-card.soon    { background: var(--u-soon-bg);    border-color: rgba(176,135,31,0.22); }
+.lp-urg-card.normal  { background: var(--brand-50);     border-color: rgba(79,70,229,0.18); }
+.lp-urg-card .lbl { font-family: "JetBrains Mono", monospace; font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; font-weight: 600; }
+.lp-urg-card.overdue .lbl { color: var(--u-overdue); }
+.lp-urg-card.today   .lbl { color: var(--u-today); }
+.lp-urg-card.soon    .lbl { color: var(--u-soon); }
+.lp-urg-card.normal  .lbl { color: var(--brand); }
+.lp-urg-card h3 { margin: 10px 0 0; font-family: "Noto Sans JP", serif; font-weight: 900; font-size: 32px; letter-spacing: -0.03em; color: var(--ink); }
+.lp-urg-card p { margin: 14px 0 0; font-size: 13px; line-height: 1.6; color: var(--ink-2); }
+.lp-urg-ring { position: relative; width: 130px; height: 130px; margin: 20px auto 0; }
+.lp-urg-ring svg { width: 100%; height: 100%; transform: rotate(-90deg); }
+.lp-urg-ring .bg { stroke: rgba(15,13,26,0.08); }
+.lp-urg-ring .fg {
+  fill: none; stroke-width: 8; stroke-linecap: round;
+  stroke-dasharray: 320; stroke-dashoffset: 320;
+  transition: stroke-dashoffset 1.6s cubic-bezier(.2,.8,.2,1);
+}
+.lp-urg-card.in-view .lp-urg-ring .fg { stroke-dashoffset: var(--off); }
+.lp-urg-card.overdue .lp-urg-ring .fg { stroke: var(--u-overdue); }
+.lp-urg-card.today   .lp-urg-ring .fg { stroke: var(--u-today); }
+.lp-urg-card.soon    .lp-urg-ring .fg { stroke: var(--u-soon); }
+.lp-urg-card.normal  .lp-urg-ring .fg { stroke: var(--brand); }
+.lp-urg-ring .center { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; font-variant-numeric: tabular-nums; }
+.lp-urg-ring .n { font-size: 32px; font-weight: 900; letter-spacing: -0.04em; color: var(--ink); line-height: 1; }
+.lp-urg-card.overdue .lp-urg-ring .n { color: var(--u-overdue); font-size: 22px; }
+.lp-urg-card.today   .lp-urg-ring .n { color: var(--u-today); }
+.lp-urg-ring .u { margin-top: 4px; font-family: "JetBrains Mono", monospace; font-size: 9px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-3); }
+
+/* ── features (bento) ─────────────────────────────────────── */
+.lp-features { padding: 140px 32px; background: var(--paper-2); position: relative; }
+.lp-features-head { max-width: 1280px; margin: 0 auto 60px; }
+.lp-features-head h2 { margin: 14px 0 0; font-family: "Noto Sans JP", serif; font-weight: 900; font-size: clamp(36px, 4.5vw, 64px); letter-spacing: -0.035em; line-height: 1.1; max-width: 18ch; }
+.lp-bento { max-width: 1280px; margin: 0 auto; display: grid; grid-template-columns: repeat(12, 1fr); grid-auto-rows: minmax(180px, auto); gap: 18px; }
+.lp-bento-cell {
+  background: var(--card); border: 1px solid var(--rule); border-radius: 22px;
+  padding: 28px; display: flex; flex-direction: column; justify-content: space-between;
+  position: relative; overflow: hidden;
+  transition: transform .35s cubic-bezier(.2,.8,.2,1), box-shadow .35s, border-color .35s;
+}
+.lp-bento-cell:hover { transform: translateY(-4px); border-color: var(--ink-3); box-shadow: 0 30px 60px -30px rgba(15,13,26,0.25); }
+.lp-bento .b-1 { grid-column: span 7; grid-row: span 2; background: var(--ink); color: var(--paper); }
+.lp-bento .b-2 { grid-column: span 5; }
+.lp-bento .b-3 { grid-column: span 5; }
+.lp-bento .b-4 { grid-column: span 4; }
+.lp-bento .b-5 { grid-column: span 4; }
+.lp-bento .b-6 { grid-column: span 4; background: var(--u-today-bg); border-color: rgba(233,101,28,0.18); }
+@media (max-width: 980px) {
+  .lp-bento { grid-template-columns: repeat(2, 1fr); }
+  .lp-bento .b-1 { grid-column: span 2; grid-row: auto; }
+  .lp-bento .b-2, .lp-bento .b-3, .lp-bento .b-4, .lp-bento .b-5, .lp-bento .b-6 { grid-column: span 1; }
+}
+@media (max-width: 560px) {
+  .lp-bento { grid-template-columns: 1fr; }
+  .lp-bento .lp-bento-cell { grid-column: span 1 !important; }
+}
+.lp-bento-cell h3 { margin: 0; font-family: "Noto Sans JP", serif; font-weight: 800; font-size: 22px; letter-spacing: -0.025em; line-height: 1.25; }
+.lp-bento-cell p { margin: 8px 0 0; font-size: 13px; line-height: 1.65; color: var(--ink-3); }
+.lp-bento .b-1 p { color: rgba(255,255,255,0.65); }
+.lp-b-icon { width: 38px; height: 38px; border-radius: 10px; background: var(--paper-2); color: var(--ink-2); display: inline-flex; align-items: center; justify-content: center; font-family: "JetBrains Mono", monospace; font-size: 13px; font-weight: 700; margin-bottom: 12px; }
+.lp-bento .b-1 .lp-b-icon { background: rgba(255,255,255,0.1); color: white; }
+.lp-bento .b-6 .lp-b-icon { background: var(--u-today); color: white; }
+.lp-b1-visual { margin-top: 22px; display: flex; align-items: center; gap: 24px; }
+.lp-timer-big { font-family: "Noto Sans JP", serif; font-weight: 900; font-size: clamp(72px, 9vw, 140px); letter-spacing: -0.05em; line-height: 0.85; color: white; font-variant-numeric: tabular-nums; }
+.lp-timer-big .unit { font-size: 0.32em; color: rgba(255,255,255,0.45); font-family: "JetBrains Mono", monospace; letter-spacing: 0; text-transform: uppercase; margin-left: 8px; vertical-align: middle; }
+.lp-timer-meta { flex: 1; border-left: 1px solid rgba(255,255,255,0.12); padding-left: 22px; }
+.lp-timer-meta .k { font-family: "JetBrains Mono", monospace; font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; color: rgba(255,255,255,0.5); }
+.lp-timer-meta .v { margin-top: 6px; font-size: 18px; font-weight: 700; }
+.lp-timer-bar { margin-top: 24px; height: 6px; background: rgba(255,255,255,0.1); border-radius: 999px; overflow: hidden; }
+.lp-timer-bar > div { height: 100%; width: 72%; background: linear-gradient(90deg, var(--brand), var(--u-today)); border-radius: 999px; animation: lpPulseBar 2.8s ease-in-out infinite; }
+.lp-schedule { margin-top: 16px; display: flex; gap: 6px; flex-wrap: wrap; }
+.lp-schedule span { font-family: "JetBrains Mono", monospace; font-size: 11px; font-weight: 700; padding: 4px 9px; border-radius: 6px; background: var(--brand-50); color: var(--brand); }
+.lp-bento .b-6 .lp-schedule span { background: rgba(255,255,255,0.6); color: var(--u-today); }
+.lp-kinds-row { margin-top: 16px; display: flex; gap: 8px; flex-wrap: wrap; }
+.lp-kinds-row .k { font-family: "JetBrains Mono", monospace; font-size: 11px; font-weight: 700; padding: 4px 9px; border-radius: 5px; }
+.lp-kinds-row .k.k-es { background: #e9defb; color: #5b3a93; }
+.lp-kinds-row .k.k-brief { background: #d8eef0; color: #1f6168; }
+.lp-kinds-row .k.k-itv { background: #fde0c8; color: #a04316; }
+.lp-kinds-row .k.k-other { background: var(--paper-2); color: var(--ink-2); }
+.lp-theme-swatches { margin-top: 16px; display: flex; gap: 8px; }
+.lp-theme-swatches span { width: 28px; height: 28px; border-radius: 7px; border: 1.5px solid var(--rule); }
+.lp-theme-swatches .s1 { background: #4f46e5; }
+.lp-theme-swatches .s2 { background: #7c3aed; }
+.lp-theme-swatches .s3 { background: #c2410c; }
+.lp-theme-swatches .s4 { background: var(--ink); }
+
+/* ── voices ─────────────────────────────────────────────── */
+.lp-voices { padding: 140px 32px; background: var(--paper); }
+.lp-voices-head { max-width: 1280px; margin: 0 auto 60px; display: grid; grid-template-columns: 1fr 1fr; gap: 60px; align-items: end; }
+@media (max-width: 880px) { .lp-voices-head { grid-template-columns: 1fr; gap: 24px; } }
+.lp-voices-head h2 { margin: 14px 0 0; font-family: "Noto Sans JP", serif; font-weight: 900; font-size: clamp(36px, 4.5vw, 64px); letter-spacing: -0.035em; line-height: 1.1; }
+.lp-voices-head p { font-size: 15px; line-height: 1.7; color: var(--ink-2); margin: 0; }
+.lp-voice-grid { max-width: 1280px; margin: 0 auto; display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+@media (max-width: 880px) { .lp-voice-grid { grid-template-columns: 1fr; } }
+.lp-voice {
+  background: var(--card); border: 1px solid var(--rule); border-radius: 22px;
+  padding: 28px; display: flex; flex-direction: column; gap: 18px;
+  opacity: 0; transform: translateY(20px);
+  transition: opacity .9s cubic-bezier(.2,.8,.2,1), transform .9s cubic-bezier(.2,.8,.2,1);
+  position: relative; overflow: hidden;
+}
+.lp-voice.in-view { opacity: 1; transform: translateY(0); }
+.lp-voice:nth-child(2) { transition-delay: 120ms; }
+.lp-voice:nth-child(3) { transition-delay: 240ms; }
+.lp-voice .quote-mark { font-family: "Noto Sans JP", serif; font-size: 80px; line-height: 0.6; color: var(--u-today); margin-bottom: -16px; }
+.lp-voice blockquote { margin: 0; font-size: 18px; font-weight: 600; letter-spacing: -0.015em; line-height: 1.55; color: var(--ink); flex: 1; }
+.lp-voice blockquote em { font-style: normal; background: linear-gradient(180deg, transparent 60%, var(--u-soon-bg) 60%); padding: 0 2px; }
+.lp-voice .who { display: flex; align-items: center; gap: 12px; padding-top: 18px; border-top: 1px solid var(--rule); }
+.lp-voice .who .avatar { width: 42px; height: 42px; border-radius: 50%; background: var(--paper-2); color: var(--ink-2); display: inline-flex; align-items: center; justify-content: center; font-weight: 800; font-size: 14px; font-family: "Noto Sans JP", serif; }
+.lp-voice .who .meta { line-height: 1.3; }
+.lp-voice .who .nm { font-size: 13px; font-weight: 700; }
+.lp-voice .who .role { font-family: "JetBrains Mono", monospace; font-size: 10px; color: var(--ink-3); letter-spacing: 0.06em; }
+
+/* ── pricing ──────────────────────────────────────────── */
+.lp-pricing { padding: 140px 32px; background: var(--paper-2); text-align: center; }
+.lp-pricing .lp-eyebrow { justify-content: center; }
+.lp-pricing h2 { margin: 18px auto 0; font-family: "Noto Sans JP", serif; font-weight: 900; font-size: clamp(36px, 4.5vw, 64px); letter-spacing: -0.035em; line-height: 1.1; max-width: 22ch; }
+.lp-price-cards { max-width: 820px; margin: 50px auto 0; display: grid; grid-template-columns: 1fr 1fr; gap: 20px; text-align: left; }
+@media (max-width: 640px) { .lp-price-cards { grid-template-columns: 1fr; } }
+.lp-price-card { background: var(--card); border-radius: 28px; padding: 44px 40px; border: 1px solid var(--rule); box-shadow: 0 40px 80px -40px rgba(15,13,26,0.25); }
+.lp-price-card.featured { background: var(--ink); color: var(--paper); border-color: transparent; position: relative; overflow: hidden; }
+.lp-price-card.featured::before { content: "〆"; position: absolute; right: -20px; bottom: -60px; font-family: "Noto Sans JP", serif; font-weight: 900; font-size: 200px; color: rgba(255,255,255,0.04); line-height: 1; pointer-events: none; }
+.lp-price-tag { display: flex; align-items: baseline; gap: 4px; font-variant-numeric: tabular-nums; }
+.lp-price-tag .y { font-family: "Noto Sans JP", serif; font-weight: 800; font-size: 28px; color: var(--ink-3); }
+.lp-price-card.featured .lp-price-tag .y { color: rgba(255,255,255,0.5); }
+.lp-price-tag .n { font-family: "Noto Sans JP", serif; font-weight: 900; font-size: 72px; letter-spacing: -0.05em; line-height: 1; }
+.lp-price-tag .u { font-size: 14px; color: var(--ink-3); margin-left: 8px; font-family: "JetBrains Mono", monospace; }
+.lp-price-card.featured .lp-price-tag .u { color: rgba(255,255,255,0.5); }
+.lp-price-card .note { margin-top: 4px; font-size: 13px; color: var(--ink-3); }
+.lp-price-card.featured .note { color: rgba(255,255,255,0.55); }
+.lp-price-list { margin: 26px 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 12px; }
+.lp-price-list li { display: flex; align-items: flex-start; gap: 12px; font-size: 14px; color: var(--ink-2); }
+.lp-price-card.featured .lp-price-list li { color: rgba(255,255,255,0.8); }
+.lp-price-list li::before {
+  content: ""; width: 18px; height: 18px; border-radius: 50%; flex-shrink: 0; margin-top: 2px;
+  background: var(--s-done-bg);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%231f8a5b' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'><polyline points='20 6 9 17 4 12'/></svg>");
+  background-repeat: no-repeat; background-position: center;
+}
+.lp-price-card.featured .lp-price-list li::before {
+  background-color: rgba(255,255,255,0.1);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'><polyline points='20 6 9 17 4 12'/></svg>");
+}
+.lp-plan-label { font-family: "JetBrains Mono", monospace; font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--ink-4); margin-bottom: 14px; display: block; }
+.lp-price-card.featured .lp-plan-label { color: rgba(255,255,255,0.5); }
+.lp-price-badge { display: inline-flex; background: var(--brand-50); color: var(--brand); font-family: "JetBrains Mono", monospace; font-size: 10px; font-weight: 700; letter-spacing: 0.1em; padding: 3px 8px; border-radius: 6px; margin-left: 8px; }
+
+/* ── final CTA ────────────────────────────────────────── */
+.lp-cta { padding: 160px 32px 120px; background: var(--ink); color: var(--paper); position: relative; overflow: hidden; }
+.lp-cta-mark {
+  position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+  pointer-events: none; font-family: "Noto Sans JP", serif; font-weight: 900;
+  font-size: clamp(400px, 60vw, 1000px); color: rgba(255,255,255,0.04);
+  line-height: 0.85; user-select: none; letter-spacing: -0.06em; z-index: 0;
+}
+.lp-cta-inner { position: relative; z-index: 2; max-width: 880px; margin: 0 auto; text-align: center; }
+.lp-cta-inner .lp-eyebrow { color: rgba(255,255,255,0.55); justify-content: center; }
+.lp-cta-inner .lp-eyebrow .dot { background: var(--u-today); }
+.lp-cta-inner h2 { margin: 22px 0 0; font-family: "Noto Sans JP", serif; font-weight: 900; font-size: clamp(46px, 6.5vw, 110px); letter-spacing: -0.045em; line-height: 0.98; }
+.lp-cta-inner h2 em { font-style: normal; color: var(--u-today); }
+.lp-cta-inner p { margin: 28px auto 0; font-size: 16px; line-height: 1.7; color: rgba(255,255,255,0.7); max-width: 46ch; }
+.lp-cta-form {
+  margin: 40px auto 0; max-width: 520px; display: flex; gap: 8px; padding: 6px;
+  background: rgba(255,255,255,0.05); border-radius: 999px; border: 1px solid rgba(255,255,255,0.1);
+}
+.lp-cta-form input {
+  flex: 1; background: transparent; border: none; outline: none;
+  font-size: 15px; font-family: "Inter", sans-serif;
+  padding: 14px 18px; color: var(--paper); letter-spacing: -0.005em;
+}
+.lp-cta-form input::placeholder { color: rgba(255,255,255,0.4); }
+.lp-cta-form button {
+  padding: 14px 24px; border-radius: 999px; background: var(--paper); color: var(--ink);
+  font-weight: 700; font-size: 14px; display: inline-flex; align-items: center; gap: 8px;
+  border: none; cursor: pointer; transition: background .2s; white-space: nowrap;
+  font-family: "Inter", "Noto Sans JP", sans-serif;
+}
+.lp-cta-form button:hover { background: var(--u-today); color: white; }
+.lp-cta-form button:disabled { opacity: 0.7; cursor: not-allowed; }
+.lp-cta-form .arrow { width: 22px; height: 22px; border-radius: 50%; background: var(--ink); color: var(--paper); display: inline-flex; align-items: center; justify-content: center; transition: transform .2s; }
+.lp-cta-form button:hover .arrow { background: white; color: var(--u-today); transform: rotate(-45deg); }
+.lp-cta-sent { margin: 40px auto 0; max-width: 520px; padding: 20px 28px; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.12); border-radius: 18px; font-size: 15px; color: rgba(255,255,255,0.9); }
+.lp-cta-foot { margin-top: 18px; font-family: "JetBrains Mono", monospace; font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: rgba(255,255,255,0.4); }
+
+/* ── footer ───────────────────────────────────────────── */
+.lp-footer { padding: 60px 32px 50px; background: var(--ink); color: rgba(255,255,255,0.6); border-top: 1px solid rgba(255,255,255,0.06); }
+.lp-footer-inner { max-width: 1280px; margin: 0 auto; display: flex; justify-content: space-between; align-items: center; gap: 24px; flex-wrap: wrap; font-family: "JetBrains Mono", monospace; font-size: 11px; letter-spacing: 0.08em; }
+.lp-footer .brand { display: flex; align-items: center; gap: 10px; color: var(--paper); font-family: "Inter", "Noto Sans JP", sans-serif; font-weight: 800; font-size: 14px; letter-spacing: -0.01em; }
+.lp-footer .brand .seal { width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center; font-family: "Noto Sans JP", serif; font-weight: 900; font-size: 16px; background: var(--paper); color: var(--ink); border-radius: 7px; transform: rotate(-4deg); }
+.lp-footer .links { display: flex; gap: 24px; }
+.lp-footer .links a { color: rgba(255,255,255,0.6); text-decoration: none; }
+.lp-footer .links a:hover { color: var(--paper); }
+
+/* ── keyframes ────────────────────────────────────────── */
+@keyframes lpTitleRise { to { transform: translateY(0); } }
+@keyframes lpUnderlineDraw { from { transform: scaleX(0); } to { transform: scaleX(1); } }
+@keyframes lpFadeUp { from { opacity: 0; transform: translateY(14px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes lpChipFloat { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-10px); } }
+@keyframes lpPingDot { 0% { transform: scale(1); opacity: 0.6; } 100% { transform: scale(2.8); opacity: 0; } }
+@keyframes lpMarqueeScroll { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+@keyframes lpScrollLine {
+  0%   { transform: scaleY(0.2); transform-origin: top; }
+  50%  { transform: scaleY(1); transform-origin: top; }
+  51%  { transform: scaleY(1); transform-origin: bottom; }
+  100% { transform: scaleY(0); transform-origin: bottom; }
+}
+@keyframes lpCaret { 50% { border-color: transparent; } }
+@keyframes lpPulseBar { 50% { width: 76%; } }


### PR DESCRIPTION
## Summary

- `HomePageClient.tsx` を全面刷新し、デザインファイル `landing.html` の全セクションを Next.js + React で実装
- `lp.css` を新規作成（`landing.css` 全スタイルを `lp-` プレフィックスで移植）
- `ConditionalFooter.tsx` を新規作成（LP ページではレイアウトフッターを非表示）

### 実装セクション

| セクション | 内容 |
|---|---|
| NAV | 固定ヘッダー・スクロール影・〆ロゴシール・アンカーリンク |
| HERO | タイトルアニメーション・フォンモックアップ（カウントダウン秒刻み）・浮遊チップ3枚・マウス視差効果 |
| MARQUEE | 6アイテム複製によるシームレスループ |
| PROBLEM | 82%カウントアップ（IntersectionObserver + RAF）・3.4件/23:59スタット |
| HOW | ダーク背景3ステップ + ステップビジュアル |
| URGENCY | SVG リング（stroke-dashoffset）のスクロールトリガーアニメーション |
| FEATURES | ベントーグリッド（12列）+ b-1タイマー d/h 2200ms 交互切替 |
| VOICES | 3ユーザー声カード |
| PRICING | Free（10件/24h）+ Pro（無制限/72h24h3h/¥980）2カード |
| CTA | `/api/auth/magic-link` を呼ぶ機能フォーム + 送信済み表示 |
| FOOTER | 暗色フッター（利用規約・プライバシー・お問い合わせ） |

### 齟齬の調整

- ヒーローバレット「完全無料・広告なし」→「**10件まで無料・広告なし**」
- 料金セクション：元デザインの「FREE FOREVER・無制限」→ Free（10件/24h）+ Pro（無制限/¥980）の2カードに変更

## Test plan

- [ ] トップページ（`/`）で全セクションが表示される
- [ ] スクロールで NAV に影が付く
- [ ] フォンモックアップのカウントダウンが秒刻みで動く
- [ ] URGENCY カードがスクロールで入ると SVG リングがアニメーションする
- [ ] CTA フォームにメールを入力して送信できる
- [ ] `/dashboard` 等では ConditionalFooter が表示される（LP では非表示）
- [ ] 390px（iPhone 14）・1280px（PC）で目視確認