### PR TITLE
text(dashboard): H1テキストロジックとKPIタイルラベルを更新する

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -73,8 +73,10 @@ export default async function DashboardPage() {
         style={{ letterSpacing: "-0.025em" }}
       >
         {todoItems.length === 0
-          ? "締切アイテムはありません"
-          : `今日の締切は${overdueItems.length > 0 ? `${overdueItems.length}件期限切れ` : `${todoItems.length}件あります`}。`}
+          ? "締切登録はありません"
+          : overdueItems.length > 0
+            ? `現在の締切登録：${todoItems.length}件（${overdueItems.length}件期限切れ。）`
+            : `現在の締切登録：${todoItems.length}件`}
       </h1>
 
       {/* HeroCard */}
@@ -89,7 +91,7 @@ export default async function DashboardPage() {
         <div className="mt-4 grid grid-cols-3 gap-2">
           <div className="rounded-[14px] border border-[var(--rule)] bg-[var(--card)] px-3 py-3">
             <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-[var(--ink-4)]">
-              TODO
+              登録中
             </p>
             <p
               className="mt-1 text-[24px] font-extrabold text-[var(--ink)]"
@@ -106,7 +108,7 @@ export default async function DashboardPage() {
             }`}
           >
             <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-[var(--ink-4)]">
-              OVERDUE
+              期限切れ
             </p>
             <p
               className="mt-1 text-[24px] font-extrabold"
@@ -121,7 +123,7 @@ export default async function DashboardPage() {
           </div>
           <div className="rounded-[14px] border border-[var(--rule)] bg-[var(--card)] px-3 py-3">
             <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-[var(--ink-4)]">
-              DONE
+              完了
             </p>
             <p
               className="mt-1 text-[24px] font-extrabold text-[var(--s-done)]"


### PR DESCRIPTION
## 概要

`docs/NEW_FEATURE/dashboard.md` の仕様に基づき、ダッシュボードのH1テキストとKPIタイルラベルを更新する。

## 変更内容

### H1 テキストロジック変更

| 状態 | 変更前 | 変更後 |
|---|---|---|
| アイテムなし | `締切アイテムはありません` | `締切登録はありません` |
| 期限切れあり | `{M}件期限切れ` | `現在の締切登録：{N}件（{M}件期限切れ。）` |
| 通常 | `今日の締切は{N}件あります。` | `現在の締切登録：{N}件` |

### KPI タイルラベル変更

| タイル | 変更前 | 変更後 |
|---|---|---|
| 登録中 | `TODO` | `登録中` |
| 期限切れ | `OVERDUE` | `期限切れ` |
| 完了 | `DONE` | `完了` |

## Closes

#196

## テスト計画

- [ ] `npx tsc --noEmit` パス済み
- [ ] `/dashboard` で各状態のH1とKPIラベルを目視確認