### PR TITLE
refactor: 未使用の import・export を削除する

### DIFF
--- a/src/app/deadline/[id]/edit/page.tsx
+++ b/src/app/deadline/[id]/edit/page.tsx
@@ -1,6 +1,4 @@
 import { notFound } from "next/navigation";
-import { getSession } from "@/features/auth/session";
-import { redirect } from "next/navigation";
 import { requireSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import DeadlineForm from "@/app/deadline/new/DeadlineForm";

--- a/src/features/deadlines/format.ts
+++ b/src/features/deadlines/format.ts
@@ -51,13 +51,6 @@ export function getUrgencyLevel(
   return "normal";
 }
 
-export const URGENCY_CLASS: Record<UrgencyLevel, string> = {
-  overdue: "border-l-4 border-red-500 bg-red-50",
-  today: "border-l-4 border-orange-400 bg-orange-50",
-  soon: "border-l-4 border-yellow-400 bg-yellow-50",
-  normal: "border-l-4 border-indigo-200 bg-white",
-};
-
 export const KIND_LABEL: Record<string, string> = {
   es: "ES",
   briefing: "説明会",
@@ -72,9 +65,3 @@ export const STATUS_LABEL: Record<string, string> = {
   canceled: "辞退/中止",
 };
 
-export const STATUS_COLOR: Record<string, string> = {
-  todo: "bg-slate-100 text-slate-600",
-  submitted: "bg-indigo-100 text-indigo-700",
-  done: "bg-green-100 text-green-700",
-  canceled: "bg-slate-100 text-slate-400",
-};


### PR DESCRIPTION
## 概要

使われていない import 文・export 定義を削除してコード量を削減する。

## 変更内容

### `src/app/deadline/[id]/edit/page.tsx`
- `getSession` import を削除 — `requireSession` で代替済みで本ファイルで未使用
- `redirect` import を削除 — `notFound()` で処理しており未使用

### `src/features/deadlines/format.ts`
- `URGENCY_CLASS` export 定義（6行）を削除 — プロジェクト全体でどこからも import されていない
- `STATUS_COLOR` export 定義（6行）を削除 — プロジェクト全体でどこからも import されていない

## 確認事項

- `npx tsc --noEmit` パス済み
- `npm test` 107件全パス（`format.test.ts` は `formatDeadline`/`getUrgencyLevel` のみテストしており影響なし）

## Closes

#205