### PR TITLE
feat(worker): Cron Triggerのscheduledハンドラを実装する

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:studio": "prisma studio",
     "build:cloudflare": "opennextjs-cloudflare build",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
+    "preview:cron": "opennextjs-cloudflare build && opennextjs-cloudflare preview -- --test-scheduled",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"

--- a/worker.ts
+++ b/worker.ts
@@ -1,0 +1,44 @@
+/**
+ * Cloudflare Workers エントリーポイント
+ *
+ * opennextjs-cloudflare が生成した worker.js をラップし、
+ * Cron Trigger 用の scheduled ハンドラを追加する。
+ *
+ * [triggers]
+ * crons = ["*\/10 * * * *"]   → 10 分ごとに scheduled() を呼び出す
+ *
+ * scheduled() は APP_URL/api/cron/notify へ POST し、通知メールを送信する。
+ */
+
+export * from "./.open-next/worker.js";
+
+import nextWorker from "./.open-next/worker.js";
+
+const worker = {
+  ...nextWorker,
+
+  async scheduled(
+    _event: { scheduledTime: number; cron: string },
+    env: { APP_URL: string; CRON_SECRET: string },
+    ctx: { waitUntil: (promise: Promise<unknown>) => void },
+  ): Promise<void> {
+    ctx.waitUntil(
+      fetch(`${env.APP_URL}/api/cron/notify`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${env.CRON_SECRET}` },
+      })
+        .then(async (res) => {
+          const body = await res.text();
+          console.log("[scheduled] cron/notify:", res.status, body);
+        })
+        .catch((err: unknown) => {
+          console.error(
+            "[scheduled] cron/notify failed:",
+            err instanceof Error ? err.message : String(err),
+          );
+        }),
+    );
+  },
+};
+
+export default worker;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,5 @@
 # Cloudflare Workers 設定
-# @opennextjs/cloudflare が生成した .open-next/worker.js を Deploy する
+# worker.ts が opennextjs-cloudflare の worker.js をラップし scheduled ハンドラを追加する
 # see: https://opennext.js.org/cloudflare
 #
 # ── デプロイ手順 ────────────────────────────────────────────────────
@@ -20,7 +20,7 @@
 # -------------------------------------------------------------------
 
 name = "job-hunt-tracker"
-main = ".open-next/worker.js"
+main = "worker.ts"
 compatibility_date = "2025-09-23"
 compatibility_flags = ["nodejs_compat"]
 


### PR DESCRIPTION
## 概要

Cloudflare Workers の Cron Trigger を実際に動作させるための `scheduled()` ハンドラを実装する。

これまで `wrangler.toml` に `[triggers] crons = ["*/10 * * * *"]` は定義されていたが、`scheduled()` ハンドラが存在しなかったため、本番環境でも Cron が発火しても通知メールが送信されない状態だった。

## 変更点

### `worker.ts`（新規作成）

opennextjs-cloudflare が生成する `.open-next/worker.js` をラップするエントリーポイント。

- `.open-next/worker.js` の `fetch` ハンドラをそのまま引き継ぐ
- `scheduled()` ハンドラを追加し、Cron 発火時に `APP_URL/api/cron/notify` へ POST する
- `ctx.waitUntil()` で非同期処理が Worker の終了前に完了することを保証
- 成否を `console.log` / `console.error` でログ出力

```
Cloudflare Cron（10分ごと）
  └─ scheduled() が発火
       └─ POST /api/cron/notify（CRON_SECRET 付き）
            └─ DB 検索 → Resend でメール送信
```

### `wrangler.toml`

- `main = ".open-next/worker.js"` → `main = "worker.ts"` に変更
- コメントを実態に合わせて更新

### `package.json`

- `preview:cron` スクリプトを追加
  - `opennextjs-cloudflare preview -- --test-scheduled` を実行
  - `http://localhost:8787/__scheduled?cron=*+*+*+*+*` で `scheduled()` をローカルテスト可能にする

## 動作確認

- [ ] `npx wrangler deploy --dry-run` でバンドル成功・`scheduled` ハンドラが含まれていることを確認済み
- [ ] `npm run preview:cron` 起動後に `curl "http://localhost:8787/__scheduled?cron=*+*+*+*+*"` で動作確認可能
- [ ] 本番デプロイ後は Cloudflare Dashboard の Cron Triggers タブで次回実行時刻を確認
