### PR TITLE
feat(lp): Navにログインボタンを追加して/loginへの導線を設ける

### DIFF
--- a/src/app/_components/HomePageClient.tsx
+++ b/src/app/_components/HomePageClient.tsx
@@ -255,9 +255,12 @@ export function HomePageClient() {
           <a href="#faq">FAQ</a>
           <a href="#pricing">料金</a>
         </div>
-        <a href="#cta" className="lp-nav-cta">
-          無料ではじめる <span className="arrow">→</span>
-        </a>
+        <div className="lp-nav-actions">
+          <Link href="/login" className="lp-nav-login">ログイン</Link>
+          <a href="#cta" className="lp-nav-cta">
+            無料ではじめる <span className="arrow">→</span>
+          </a>
+        </div>
       </nav>
 
       {/* ─── HERO ─── */}

--- a/src/app/lp.css
+++ b/src/app/lp.css
@@ -104,7 +104,22 @@ html { scroll-behavior: smooth; }
 .lp-nav-cta:hover { background: var(--brand); transform: translateY(-1px); }
 .lp-nav-cta .arrow { transition: transform .2s; }
 .lp-nav-cta:hover .arrow { transform: translateX(3px); }
-@media (max-width: 720px) { .lp-nav-links { display: none; } }
+.lp-nav-actions { display: flex; align-items: center; gap: 8px; }
+.lp-nav-login {
+  font-size: 13px; font-weight: 500;
+  padding: 9px 16px;
+  color: var(--ink-2);
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  display: inline-flex; align-items: center;
+  text-decoration: none;
+  transition: color .2s, border-color .2s;
+}
+.lp-nav-login:hover { color: var(--ink); border-color: var(--ink); }
+@media (max-width: 720px) {
+  .lp-nav-links { display: none; }
+  .lp-nav-login { display: none; }
+}
 
 /* ── hero ───────────────────────────────────────────────── */
 .lp-hero {


### PR DESCRIPTION
## 概要

LP の Nav に「ログイン」ゴーストボタンを追加し、既存ユーザーが `/login` へ遷移できる導線を設けた。

## 関連 Issue

Closes #213

## 変更点

- **Nav 右端に「ログイン」ボタンを追加**（`/login` へ遷移）: 既存ユーザーが再ログインする際の導線がなかったため追加
- **「無料ではじめる」CTA は変更なし**: 新規向け訴求・`#cta` スクロール動作を維持
- **`lp-nav-actions` でラップ**: 2ボタンを flex で並べる。ブランド / リンク群 / アクション群の3分割レイアウトに変更
- **モバイル（720px 以下）では「ログイン」を非表示**: Nav が込み合うのを防ぐ。モバイルからのログインは `#cta` のメールフォームで対応できる

## 動作確認

- `npx tsc --noEmit` → エラーなし
