### PR TITLE
feat(dashboard): 会社名・メモを対象としたキーワード検索を締切一覧に追加する

### DIFF
--- a/src/app/dashboard/DeadlineList.tsx
+++ b/src/app/dashboard/DeadlineList.tsx
@@ -70,16 +70,23 @@ export default function DeadlineList({ initialItems, totalCount }: Props) {
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [filter, setFilter] = useState<FilterState>("all");
+  const [searchQuery, setSearchQuery] = useState("");
 
+  const normalizedQuery = searchQuery.trim().toLowerCase();
   const filteredItems = items.filter((item) => {
-    if (filter === "todo") return item.status === "todo";
-    if (filter === "done")
-      return (
-        item.status === "done" ||
-        item.status === "submitted" ||
-        item.status === "canceled"
-      );
-    return true;
+    if (filter === "todo" && item.status !== "todo") return false;
+    if (
+      filter === "done" &&
+      item.status !== "done" &&
+      item.status !== "submitted" &&
+      item.status !== "canceled"
+    )
+      return false;
+    if (normalizedQuery === "") return true;
+    return (
+      item.companyName.toLowerCase().includes(normalizedQuery) ||
+      (item.memo ?? "").toLowerCase().includes(normalizedQuery)
+    );
   });
 
   async function handleStatusChange(id: string, newStatus: string) {
@@ -191,6 +198,15 @@ export default function DeadlineList({ initialItems, totalCount }: Props) {
         </div>
       </div>
 
+      {/* キーワード検索 */}
+      <input
+        type="search"
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+        placeholder="会社名・メモで検索"
+        className="mb-3 w-full rounded-xl border border-[var(--rule)] bg-[var(--card)] px-3 py-2 text-sm outline-none transition-colors placeholder:text-[var(--ink-4)] focus:border-brand focus:ring-2 focus:ring-brand/20"
+      />
+
       {errorMsg && (
         <div
           role="alert"
@@ -202,7 +218,9 @@ export default function DeadlineList({ initialItems, totalCount }: Props) {
 
       {filteredItems.length === 0 ? (
         <div className="mt-8 py-12 text-center text-sm text-[var(--ink-4)]">
-          該当する締切はありません
+          {normalizedQuery !== ""
+            ? `"${searchQuery.trim()}" に一致する締切はありません`
+            : "該当する締切はありません"}
         </div>
       ) : (
         <motion.ul


### PR DESCRIPTION
## 概要

ダッシュボードの締切一覧に、会社名・メモを対象としたクライアントサイドのキーワード検索を追加します。データはページ読み込み時にすでにブラウザへ渡されているため、API 追加なしでリアルタイム絞り込みを実現しています。

## 関連 Issue

Closes #220

## 変更点

- `searchQuery` state を追加し、入力値をリアルタイムに管理
- `filteredItems` のフィルタロジックをガード節形式に変更し、ステータスフィルタとキーワード検索を AND で合成
  - 対象フィールド: `companyName`（会社名）・`memo`（メモ）
  - 大文字小文字を区別しない（`.toLowerCase()` で正規化）
- セクションヘッド直下に `type="search"` の入力欄を追加（既存 input スタイルに準拠）
- 絞り込み結果が0件の場合、検索語が入力されているときは `"○○" に一致する締切はありません` というメッセージを表示

## 動作確認

- [ ] 会社名の一部を入力するとリアルタイムで絞り込まれる
- [ ] メモの一部を入力しても絞り込まれる
- [ ] ステータスフィルター（全て / 未対応 / 済）と組み合わせて AND 絞り込みが動作する
- [ ] 検索欄を空にすると全件表示に戻る
- [ ] 検索後0件の場合、入力した語を含むメッセージが表示される
- [ ] `npm run lint`（src/）・`npx tsc --noEmit`・`npm run test` がすべてパス
