### PR TITLE
fix(monitoring): error.tsx・global-error.tsxのSentryインポートを@sentry/browserに変更する

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from "@sentry/browser";
 import { useEffect } from "react";
 
 export default function Error({

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from "@sentry/browser";
 import { useEffect } from "react";
 
 export default function GlobalError({


### PR DESCRIPTION
## 概要

`error.tsx` および `global-error.tsx` の Sentry インポートを `@sentry/nextjs` から `@sentry/browser` に変更し、Cloudflare Workers のバンドルサイズ超過によるデプロイ失敗を修正する。

## 背景・原因

`"use client"` コンポーネントであるにもかかわらず `@sentry/nextjs` をインポートすると、webpack のサーバー SSR バンドル生成時にサーバー側モジュール（`index.server.js`）が解決される。これにより以下の依存チェーンが発生し、OpenTelemetry 全体がバンドルに混入していた。

```
global-error.tsx
  → @sentry/nextjs/index.server.js
    → @sentry/node
      → @prisma/instrumentation
        → @opentelemetry/instrumentation
```

結果として Worker スクリプトサイズが 8902 KiB に膨張し、Cloudflare Workers の 3 MiB 制限を超過してデプロイが失敗していた。

## 変更点

- `src/app/error.tsx`: `@sentry/nextjs` → `@sentry/browser`
- `src/app/global-error.tsx`: `@sentry/nextjs` → `@sentry/browser`

`@sentry/browser` は `@sentry/nextjs` の transitive dependency として v10.53.1 がすでにインストール済みのため、追加パッケージは不要。ブラウザ側での `captureException` の動作に変更なし。

## 動作確認

- [ ] TypeScript エラーなし（`tsc --noEmit` 通過済み）
- [ ] デプロイ後に Cloudflare Workers のバンドルサイズが 3 MiB 以内に収まること
- [ ] ブラウザエラー発生時に Sentry へ正常に送信されること
