### PR TITLE
fix(env): NEXT_PUBLIC_POSTHOG_KEYのサーバー側ランタイム検証を削除する

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -89,18 +89,9 @@ export const envSchema = z
         message: "ANALYTICS_PROVIDER=segment のとき ANALYTICS_WRITE_KEY は必須です",
       });
     }
-    // ANALYTICS_PROVIDER=posthog のとき NEXT_PUBLIC_POSTHOG_KEY が必須
-    // （NEXT_PUBLIC_ 変数は process.env 経由でサーバーサイドからも参照可能）
-    if (
-      data.ANALYTICS_PROVIDER === "posthog" &&
-      !process.env.NEXT_PUBLIC_POSTHOG_KEY
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["NEXT_PUBLIC_POSTHOG_KEY"],
-        message: "ANALYTICS_PROVIDER=posthog のとき NEXT_PUBLIC_POSTHOG_KEY は必須です",
-      });
-    }
+    // NEXT_PUBLIC_POSTHOG_KEY はビルド時にクライアントバンドルへ焼き込まれる変数のため
+    // Cloudflare Workers のサーバー runtime では process.env から参照できない。
+    // 起動時バリデーションの対象から除外し、getServerPostHog() の null チェックに委ねる。
   });
 
 // ── 一括バリデーション（起動時フェイルファスト） ──────────────────────────────


### PR DESCRIPTION
## 概要

`validateAllEnv()` 内の `NEXT_PUBLIC_POSTHOG_KEY` ランタイムチェックを削除し、`/login` 等の保護ページで発生していた 500 Internal Server Error を修正する。

## 原因

`middleware.ts` はモジュール初期化時に `validateAllEnv()` を呼び出すため、マッチするすべてのパス（`/login`, `/dashboard`, `/billing` 等）へのリクエストで検証が実行される。

`NEXT_PUBLIC_` プレフィックスを持つ変数は Next.js のビルド時にクライアントバンドルへ値が直接埋め込まれる。Cloudflare Workers のサーバー runtime では `process.env.NEXT_PUBLIC_POSTHOG_KEY` が `undefined` になるため、`ANALYTICS_PROVIDER=posthog` の環境では必ずバリデーション失敗 → 500 エラーが発生していた。

```
middleware.ts → validateAllEnv() → process.env.NEXT_PUBLIC_POSTHOG_KEY === undefined
                                         ↓
                              全保護ページで 500 Internal Server Error
```

## 変更点

- `src/lib/env.ts`: `superRefine` 内の `NEXT_PUBLIC_POSTHOG_KEY` チェックを削除
  - サーバー側 PostHog の null ハンドリングは `getServerPostHog()` の `if (!apiKey) return null` に委ねる
  - クライアント側 PostHog はビルド時に値が焼き込まれるため引き続き正常動作する

## 動作確認

- [ ] `/login`, `/billing`, `/dashboard` 等の保護ページで 500 エラーが発生しないこと
- [ ] TypeScript エラーなし（`tsc --noEmit` 通過済み）
