### PR TITLE
fix(deploy): NEXT_PUBLIC_系変数をwrangler.tomlに追加してビルド時に反映されるようにする

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -17,6 +17,9 @@ MAGIC_LINK_EXPIRY_MINUTES = "30"
 ANALYTICS_PROVIDER = "posthog"
 SENTRY_ORG = "kharuya"
 SENTRY_PROJECT = "shimetra"
+NEXT_PUBLIC_POSTHOG_KEY = "phc_rMNunbFAyC7XRtnvTMuY2ZyqCzU26cEsgCxtWGtZrrbd"
+NEXT_PUBLIC_POSTHOG_HOST = "https://app.posthog.com"
+NEXT_PUBLIC_SENTRY_DSN = "https://b908643db8df2eeedb19c484a43d9499@o4511423479545856.ingest.us.sentry.io/4511423486558208"
 
 # Cron: 10分ごとに /api/cron/notify を実行
 [triggers]


### PR DESCRIPTION
## 概要

`wrangler deploy` 実行時にダッシュボードで設定した変数が上書き削除される問題と、`next build` 時に `NEXT_PUBLIC_` 変数が渡らない問題を修正する。

## 背景・原因

`wrangler deploy` は `wrangler.toml` の `[vars]` 内容でリモート設定を上書きする。そのため、Cloudflare ダッシュボードで追加した変数はデプロイのたびに削除されていた。

また、`NEXT_PUBLIC_` 変数は `next build` 実行時にクライアントバンドルへ値が焼き込まれる必要があるが、ダッシュボードの変数はビルド環境に渡されないため、値が `undefined` のままビルドされていた。結果として PostHog・Sentry の SDK が初期化されず、計測・監視が機能していなかった。

```
wrangler deploy 実行時の警告:
vars: {
-   NEXT_PUBLIC_POSTHOG_HOST: "https://app.posthog.com"   ← 削除
-   NEXT_PUBLIC_POSTHOG_KEY: "phc_..."                    ← 削除
-   NEXT_PUBLIC_SENTRY_DSN: "https://..."                 ← 削除
}
Deploying the Worker will override the remote configuration with your local one.
```

## 変更点

- `wrangler.toml` の `[vars]` に以下の3変数を追加
  - `NEXT_PUBLIC_POSTHOG_KEY` — PostHog プロジェクト API キー
  - `NEXT_PUBLIC_POSTHOG_HOST` — PostHog ホスト URL
  - `NEXT_PUBLIC_SENTRY_DSN` — Sentry DSN

`NEXT_PUBLIC_` 変数はブラウザの JavaScript バンドルに平文で埋め込まれる公開前提の値のため、リポジトリへのコミットに問題はない。

## 動作確認

- [x] デプロイ後に Cloudflare Workers のバインディング一覧に3変数が表示されること
- [x] ブラウザの Network タブで `posthog.com` へのリクエストが確認できること
- [x] Sentry ダッシュボードにテストエラーが届くこと
