### PR TITLE
fix(monitoring): instrumentation-client.tsのSentryインポートを@sentry/browserに変更する

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from "@sentry/browser";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,


### PR DESCRIPTION
## 概要

`instrumentation-client.ts` の Sentry インポートを `@sentry/nextjs` から `@sentry/browser` に変更し、クライアント側の Sentry が正しく初期化されない問題を修正する。

## 原因

`withSentryConfig` を `next.config.js` から削除した環境では、`@sentry/nextjs` はクライアント側で `Sentry.init()` を呼び出しても完全には初期化されない。`window.__SENTRY__` に `version` と `10.53.1` のみが存在し、エラーキャプチャが機能しない状態になっていた。

`error.tsx` / `global-error.tsx` ではすでに `@sentry/browser` に切り替え済みだったが、`instrumentation-client.ts` は `@sentry/nextjs` のままになっており、クライアント SDK の初期化に失敗していた。

## 変更点

- `instrumentation-client.ts`: `@sentry/nextjs` → `@sentry/browser`
  - `error.tsx` / `global-error.tsx` と同様に `@sentry/browser` に統一
  - `@sentry/browser` は `@sentry/nextjs` の transitive dependency として v10.53.1 がインストール済みのため追加パッケージは不要

## 動作確認

- [ ] デプロイ後に `window.__SENTRY__` が正常な初期化状態になること
- [ ] ブラウザでエラーを発生させたとき Sentry ダッシュボードの Issues にエラーが届くこと
