### PR TITLE
docs(env): 環境変数の管理場所と運用方法をまとめたガイドを追加する

### DIFF
--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -1,0 +1,64 @@
+# 環境変数ガイド（〆トラ）
+
+## 変数一覧
+
+| 変数名                                        | 本番環境                        | ローカル環境 | CI環境             |
+| --------------------------------------------- | ------------------------------- | ------------ | ------------------ |
+| `ANALYTICS_PROVIDER`（非機密の固定値）        | `wrangler.toml`                 | `.env.local` | —                  |
+| `SENTRY_ORG`（非機密の固定値）                | `wrangler.toml`                 | `.env.local` | —                  |
+| `SENTRY_PROJECT`（非機密の固定値）            | `wrangler.toml`                 | `.env.local` | —                  |
+| `APP_ENV`（非機密の固定値）                   | `wrangler.toml`                 | `.env.local` | —                  |
+| `EMAIL_PROVIDER`（非機密の固定値）            | `wrangler.toml`                 | `.env.local` | —                  |
+| `MAGIC_LINK_EXPIRY_MINUTES`（非機密の固定値） | `wrangler.toml`                 | `.env.local` | —                  |
+| `APP_URL`（非機密の固定値）                   | CF シークレット                 | `.env.local` | —                  |
+| `EMAIL_FROM`（非機密の固定値）                | CF シークレット                 | `.env.local` | —                  |
+| `STRIPE_PRICE_ID`（非機密の固定値）           | CF シークレット                 | `.env.local` | `ci.yml`（ダミー） |
+| `DATABASE_URL`（機密情報）                    | CF シークレット                 | `.env.local` | `ci.yml`（ダミー） |
+| `DATABASE_URL_UNPOOLED`（機密情報）           | CF シークレット                 | `.env.local` | —                  |
+| `AUTH_SECRET`（機密情報）                     | CF シークレット                 | `.env.local` | `ci.yml`（ダミー） |
+| `RESEND_API_KEY`（機密情報）                  | CF シークレット                 | `.env.local` | —                  |
+| `STRIPE_SECRET_KEY`（機密情報）               | CF シークレット                 | `.env.local` | `ci.yml`（ダミー） |
+| `STRIPE_WEBHOOK_SECRET`（機密情報）           | CF シークレット                 | `.env.local` | `ci.yml`（ダミー） |
+| `CRON_SECRET`（機密情報）                     | CF シークレット                 | `.env.local` | `ci.yml`（ダミー） |
+| `UPSTASH_REDIS_REST_URL`（機密情報）          | CF シークレット                 | `.env.local` | —                  |
+| `UPSTASH_REDIS_REST_TOKEN`（機密情報）        | CF シークレット                 | `.env.local` | —                  |
+| `NEXT_PUBLIC_POSTHOG_KEY`                     | `wrangler.toml` + CF ビルド設定 | `.env.local` | —                  |
+| `NEXT_PUBLIC_POSTHOG_HOST`                    | `wrangler.toml` + CF ビルド設定 | `.env.local` | —                  |
+| `NEXT_PUBLIC_SENTRY_DSN`                      | `wrangler.toml` + CF ビルド設定 | `.env.local` | —                  |
+
+**凡例**
+
+- `CF シークレット` = Cloudflare ダッシュボード → Settings → Variables and Secrets（暗号化）
+- `CF ビルド設定` = Cloudflare ダッシュボード → Settings → Build → Variables and Secrets
+- `wrangler.toml` = リポジトリの `wrangler.toml [vars]`（コードで管理）
+- `ci.yml`（ダミー） = `.github/workflows/ci.yml` の `env:` ブロックにダミー値を直書き
+- `—` = 設定不要
+
+---
+
+## NEXT*PUBLIC* 変数の注意事項
+
+### なぜ2か所に設定するのか
+
+```
+【ブラウザ用】CF ビルド設定
+  → next build 時に値がJSファイルへ直接書き込まれる
+  → ブラウザに届くJSの中に値が含まれる
+
+【サーバー用】wrangler.toml
+  → Cloudflare Workers 実行時に process.env から読まれる
+  → サーバー側コード（getServerPostHog() など）で使われる
+```
+
+Vercel では1か所の設定で両方に届くが、Cloudflare Workers では構造上2か所への設定が必要。
+
+### 変更時の手順
+
+`NEXT_PUBLIC_` 変数を追加・変更する場合は以下の **3か所すべて** を更新する。
+
+1. `wrangler.toml [vars]` を編集
+2. CF ダッシュボード → ビルド設定 → 変数とシークレット を更新
+3. PR マージ後、CF ダッシュボードから **Retry build** を実行
+
+> **注意**: ビルド設定の変更は Retry build を実行しないと反映されない。
+> 通常のデプロイ（コードの push）だけでは不十分。

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -10,9 +10,9 @@
 | `APP_ENV`（非機密の固定値）                   | `wrangler.toml`                 | `.env.local` | —                  |
 | `EMAIL_PROVIDER`（非機密の固定値）            | `wrangler.toml`                 | `.env.local` | —                  |
 | `MAGIC_LINK_EXPIRY_MINUTES`（非機密の固定値） | `wrangler.toml`                 | `.env.local` | —                  |
-| `APP_URL`（非機密の固定値）                   | CF シークレット                 | `.env.local` | —                  |
-| `EMAIL_FROM`（非機密の固定値）                | CF シークレット                 | `.env.local` | —                  |
-| `STRIPE_PRICE_ID`（非機密の固定値）           | CF シークレット                 | `.env.local` | `ci.yml`（ダミー） |
+| `APP_URL`（非機密の固定値）                   | `wrangler.toml`                 | `.env.local` | —                  |
+| `EMAIL_FROM`（非機密の固定値）                | `wrangler.toml`                 | `.env.local` | —                  |
+| `STRIPE_PRICE_ID`（非機密の固定値）           | `wrangler.toml`                 | `.env.local` | `ci.yml`（ダミー） |
 | `DATABASE_URL`（機密情報）                    | CF シークレット                 | `.env.local` | `ci.yml`（ダミー） |
 | `DATABASE_URL_UNPOOLED`（機密情報）           | CF シークレット                 | `.env.local` | —                  |
 | `AUTH_SECRET`（機密情報）                     | CF シークレット                 | `.env.local` | `ci.yml`（ダミー） |

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -20,6 +20,9 @@ SENTRY_PROJECT = "shimetra"
 NEXT_PUBLIC_POSTHOG_KEY = "phc_rMNunbFAyC7XRtnvTMuY2ZyqCzU26cEsgCxtWGtZrrbd"
 NEXT_PUBLIC_POSTHOG_HOST = "https://app.posthog.com"
 NEXT_PUBLIC_SENTRY_DSN = "https://b908643db8df2eeedb19c484a43d9499@o4511423479545856.ingest.us.sentry.io/4511423486558208"
+APP_URL = "https://shimetra.com"
+EMAIL_FROM = "noreply@shimetra.com"
+STRIPE_PRICE_ID = "price_1TCcgeHhfBJUWmdwVKaGQ5Gh"
 
 # Cron: 10分ごとに /api/cron/notify を実行
 [triggers]


### PR DESCRIPTION
## 概要

環境変数の管理場所・運用手順をまとめたガイドドキュメント（`docs/ENV.md`）を追加する。

## 変更点

- `docs/ENV.md` を新規作成
  - 全環境変数を「変数名／本番環境／ローカル環境／CI環境」の表で一覧化
  - 各変数の機密性（機密情報 / 非機密の固定値）を明記
  - `NEXT_PUBLIC_` 変数の2か所設定が必要な理由と変更手順を記述
  - `wrangler.toml`・CF シークレット・CF ビルド設定・`.env.local`・`ci.yml` の役割を整理

## 動作確認

ドキュメントのみの変更のため、コード動作への影響なし。
