### PR TITLE
fix(tsconfig): prisma.config.ts の process 型エラーを解消する

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,10 +27,11 @@
         "./src/*"
       ]
     },
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "node"]
   },
   "include": [
     "next-env.d.ts",
+    "prisma.config.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
     ".next/types/**/*.ts",


### PR DESCRIPTION
## 概要

`prisma.config.ts` で `process.env` を参照しているにもかかわらず、TypeScript が `process` を認識できず型エラーが発生していた問題を修正します。

Closes #239

## 変更点

### `tsconfig.json`

- `types` に `"node"` を追加し、`@types/node`（インストール済み）の型定義が適用されるようにした
- `include` に `"prisma.config.ts"` を追加し、型チェック対象に含めた

**原因：**

`"types": ["vitest/globals"]` と明示することで `@types/node` の自動適用が無効化されており、かつ `prisma.config.ts` が `include` 対象外だったため、`process` の型が解決されていなかった。`@types/node` 自体はインストール済みのため、パッケージ追加は不要。

## 動作確認

- [ ] `npx tsc --noEmit` でエラーが発生しないことを確認（✅ 確認済み）
- [ ] `prisma.config.ts` の `process.env` に型エラーが表示されないことを VS Code で確認
